### PR TITLE
Update liveness/ready probes for prometheus

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -62,10 +62,15 @@ spec:
             - containerPort: 9093
           readinessProbe:
             httpGet:
-              path: /#/status
+              path: /-/ready
               port: 9093
-            initialDelaySeconds: 30
             timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9093
+            timeoutSeconds: 30
+            initialDelaySeconds: 30
 
           volumeMounts:
             - name: config-volume

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -79,6 +79,19 @@ spec:
               mountPath: /monitor-data
           ports:
             - containerPort: 8180
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 8180
+              scheme: HTTP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 8180
+              scheme: HTTP
+            initialDelaySeconds: 30
 
         - name: prometheus-server-configmap-reload
           image: jimmidyson/configmap-reload:{{ .Values.configMapReloadVersion }}
@@ -105,10 +118,15 @@ spec:
             - containerPort: 9090
           readinessProbe:
             httpGet:
-              path: /status
+              path: /-/ready
               port: 9090
-            initialDelaySeconds: 30
             timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+            timeoutSeconds: 30
+            initialDelaySeconds: 30
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -11,7 +11,7 @@ esGrafanaVersion: v0.0.10
 # prom/prometheus
 prometheusVersion: v2.2.1
 # prom/alertmanager
-alertManagerVersion: v0.14.0
+alertManagerVersion: v0.15.1
 # jimmidyson/configmap-reload
 configMapReloadVersion: v0.2.2
 # default image pull  policy


### PR DESCRIPTION
Use the correct endpoints (status can timeout, /-/ready and /-/healthy are
the correct endpoints). Also add liveness/ready for es-monitor-api to
pick up issues on the k8s layer. Bumped alertmanager version for the
/-/ready endpoint.