### PR TITLE
Make prometheus annotation domain configurable

### DIFF
--- a/enterprise-suite/prometheus-server/prometheus.yml
+++ b/enterprise-suite/prometheus-server/prometheus.yml
@@ -1,3 +1,5 @@
+{{- $promDomainUnderscored := .Values.prometheusDomain | replace "." "_" }}
+
 global:
   # dev mode
   scrape_interval: 10s
@@ -94,11 +96,11 @@ scrape_configs:
   # The relabeling allows the actual service scrape endpoint to be configured
   # via the following annotations:
   #
-  # * `prometheus.io/scrape`: Only scrape services that have a value of `true`
-  # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
+  # * `{{ .Values.prometheusDomain }}/scrape`: Only scrape services that have a value of `true`
+  # * `{{ .Values.prometheusDomain }}/scheme`: If the metrics endpoint is secured then you will need
   # to set this to `https` & most likely set the `tls_config` of the scrape config.
-  # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-  # * `prometheus.io/port`: If the metrics are exposed on a different port to the
+  # * `{{ .Values.prometheusDomain }}/path`: If the metrics path is not `/metrics` override this.
+  # * `{{ .Values.prometheusDomain }}/port`: If the metrics are exposed on a different port to the
   # service then set this appropriately.
   - job_name: 'kubernetes-service-endpoints'
 
@@ -106,18 +108,18 @@ scrape_configs:
       - role: endpoints
 
     relabel_configs:
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+      - source_labels: [__meta_kubernetes_service_annotation_{{ $promDomainUnderscored }}_scrape]
         action: keep
         regex: true
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+      - source_labels: [__meta_kubernetes_service_annotation_{{ $promDomainUnderscored }}_scheme]
         action: replace
         target_label: __scheme__
         regex: (https?)
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+      - source_labels: [__meta_kubernetes_service_annotation_{{ $promDomainUnderscored }}_path]
         action: replace
         target_label: __metrics_path__
         regex: (.+)
-      - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+      - source_labels: [__address__, __meta_kubernetes_service_annotation_{{ $promDomainUnderscored }}_port]
         action: replace
         target_label: __address__
         regex: (.+)(?::\d+);(\d+)
@@ -165,7 +167,7 @@ scrape_configs:
       - role: service
 
     relabel_configs:
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
+      - source_labels: [__meta_kubernetes_service_annotation_{{ $promDomainUnderscored }}_probe]
         action: keep
         regex: pushgateway
 
@@ -174,7 +176,7 @@ scrape_configs:
   # The relabeling allows the actual service scrape endpoint to be configured
   # via the following annotations:
   #
-  # * `prometheus.io/probe`: Only probe services that have a value of `true`
+  # * `{{ .Values.prometheusDomain }}/probe`: Only probe services that have a value of `true`
   - job_name: 'kubernetes-services'
 
     metrics_path: /probe
@@ -185,7 +187,7 @@ scrape_configs:
       - role: service
 
     relabel_configs:
-      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
+      - source_labels: [__meta_kubernetes_service_annotation_{{ $promDomainUnderscored }}_probe]
         action: keep
         regex: true
       - source_labels: [__address__]
@@ -206,23 +208,23 @@ scrape_configs:
   # The relabeling allows the actual pod scrape endpoint to be configured via the
   # following annotations:
   #
-  # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
-  # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
-  # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the default of `9102`.
+  # * `{{ .Values.prometheusDomain }}/scrape`: Only scrape pods that have a value of `true`
+  # * `{{ .Values.prometheusDomain }}/path`: If the metrics path is not `/metrics` override this.
+  # * `{{ .Values.prometheusDomain }}/port`: Scrape the pod on the indicated port instead of the default of `9102`.
   - job_name: 'kubernetes-pods'
 
     kubernetes_sd_configs:
       - role: pod
 
     relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+      - source_labels: [__meta_kubernetes_pod_annotation_{{ $promDomainUnderscored }}_scrape]
         action: keep
         regex: true
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+      - source_labels: [__meta_kubernetes_pod_annotation_{{ $promDomainUnderscored }}_path]
         action: replace
         target_label: __metrics_path__
         regex: (.+)
-      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_{{ $promDomainUnderscored }}_port]
         action: replace
         regex: (.+):(?:\d+);(\d+)
         replacement: ${1}:${2}

--- a/enterprise-suite/templates/es-demo.yaml
+++ b/enterprise-suite/templates/es-demo.yaml
@@ -8,7 +8,7 @@ spec:
   template:
     metadata:
       annotations:
-        prometheus.io/scrape: "true"
+        {{ .Values.prometheusDomain }}/scrape: "true"
       labels:
         app: es-demo
     spec:

--- a/enterprise-suite/templates/kube-state-metrics.yaml
+++ b/enterprise-suite/templates/kube-state-metrics.yaml
@@ -92,7 +92,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    prometheus.io/scrape: "true"
+    {{ .Values.prometheusDomain }}/scrape: "true"
   labels:
     app: prometheus
     component: "kube-state-metrics"

--- a/enterprise-suite/templates/node-exporter.yaml
+++ b/enterprise-suite/templates/node-exporter.yaml
@@ -58,7 +58,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    prometheus.io/scrape: "true"
+    {{ .Values.prometheusDomain }}/scrape: "true"
   labels:
     app: prometheus
     component: "node-exporter"

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -180,7 +180,7 @@ metadata:
     component: server
   name: prometheus-server
 data:
-{{ (.Files.Glob "prometheus-server/*").AsConfig | indent 2 }}
+{{ (tpl (.Files.Glob "prometheus-server/*").AsConfig .) | indent 2 }}
 
 ---
 apiVersion: v1

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -1,5 +1,6 @@
+#################################################
 # Update these versions for a release.
-
+#
 # lightbend-docker-registry.bintray.io/enterprise-suite/es-console
 esConsoleVersion: v0.0.11
 # lightbend-docker-registry.bintray.io/enterprise-suite/es-monitor-api
@@ -14,5 +15,11 @@ prometheusVersion: v2.2.1
 alertManagerVersion: v0.14.0
 # jimmidyson/configmap-reload
 configMapReloadVersion: v0.2.2
+
+#################################################
+# Settings
+#
 # default image pull  policy
 imagePullPolicy: IfNotPresent
+# prometheus annotation domain, e.g. `domain/scrape=true`
+prometheusDomain: prometheus.io


### PR DESCRIPTION
For https://github.com/lightbend/es-backend/issues/175.

I've left domain as `prometheus.io` so nothing else changes. This change
just makes it easy to change the domain in the future, as I believe we
should be namespacing to an ES specific domain for ES prometheus.