### PR TITLE
make it a good hack

### DIFF
--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -113,7 +113,7 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["/bin/sh", "-c", "sleep 15 && curl -XPOST 'admin:admin@127.0.0.1:3000/api/plugins/cinnamon-prometheus-app/settings?enabled=true' -d '' || true" ]
+              command: ["/bin/sh", "-c", "echo \"Waiting for grafana to enable cinnamon plugin...\"; until curl --output /dev/null --silent --head --fail curl http://127.0.0.1:3000; do echo -n '.' ;  sleep 2; done ; curl -XPOST 'admin:admin@127.0.0.1:3000/api/plugins/cinnamon-prometheus-app/settings?enabled=true' -d '' || true" ]
         readinessProbe:
           httpGet:
             path: /login


### PR DESCRIPTION
Wait till grafana comes up and then enable cinnamon plugin.. 
This is only temporary fix.. I will investigate make this enabled by default and burn it into es-grafana image