### PR TITLE
wrap node port exposes in minikube flag

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -90,6 +90,7 @@ spec:
           configMap:
             name: prometheus-alertmanager
 
+{{ if .Values.minikube }}
 ---
 apiVersion: v1
 kind: Service
@@ -105,3 +106,4 @@ spec:
     app: prometheus
     component: alertmanager
   type: NodePort
+{{ end }}

--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -24,6 +24,7 @@ spec:
           configMap:
             name: es-console
 
+{{ if .Values.minikube }}
 ---
 apiVersion: v1
 kind: Service
@@ -38,6 +39,7 @@ spec:
   selector:
     run: es-console
   type: NodePort
+{{ end }}
 
 ---
 apiVersion: v1

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -62,6 +62,7 @@ spec:
     component: "server"
   type: "ClusterIP"
 
+{{ if .Values.minikube }}
 ---
 apiVersion: v1
 kind: Service
@@ -77,6 +78,7 @@ spec:
     app: grafana
     component: server
   type: NodePort
+{{ end }}
 
 ---
 apiVersion: extensions/v1beta1

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -173,6 +173,7 @@ spec:
     app: prometheus
     component: server
 
+{{ if .Values.minikube }}
 ---
 apiVersion: v1
 kind: Service
@@ -188,6 +189,7 @@ spec:
     app: prometheus
     component: server
   type: NodePort
+{{ end }}
 
 ---
 apiVersion: v1

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -23,3 +23,5 @@ configMapReloadVersion: v0.2.2
 imagePullPolicy: IfNotPresent
 # prometheus annotation domain, e.g. `domain/scrape=true`
 prometheusDomain: prometheus.io
+# minikube debug resources
+minikube: true


### PR DESCRIPTION
helm --set minikube=false  to skip the node port exposes

part of lightbend/es-backend#216