### PR TITLE
Namespace aggregation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ docs/$(RELEASE_LATEST).tgz: $(CHART)/Chart.yaml $(CHART)/templates/*.yaml
 	scripts/munge-to-latest.sh build/$(CHART_LATEST)
 	helm package build/$(CHART_LATEST) -d docs
 
+# duplicate method here to generate the index, to avoid pulling in RELEASE as a dependency
+latest: init lint docs/es/all-latest.yaml docs/$(RELEASE_LATEST).tgz
+	helm repo index docs --url https://lightbend.github.io/helm-charts
+
 clean:
 	rm -rf build
 
@@ -63,5 +67,8 @@ delete-es:
 install-local: install-helm delete-es
 	helm install docs/$(RELEASE).tgz --name=es --namespace=lightbend --debug
 
+install-local-latest: docs/$(RELEASE_LATEST).tgz install-helm delete-es
+	helm install docs/$(RELEASE_LATEST).tgz --name=es --namespace=lightbend --debug
+
 # always run these steps if in dependencies:
-.PHONY: all build install-local install-helm delete-es lint init clean lint-json lint-promql
+.PHONY: all build install-local install-local-latest install-helm delete-es lint init clean lint-json lint-promql latest

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ docs/index.yaml: docs/$(RELEASE).tgz docs/$(RELEASE_LATEST).tgz
 	$(call banner)
 	helm repo index docs --url https://lightbend.github.io/helm-charts
 
-docs/$(RELEASE).tgz: $(CHART)/Chart.yaml $(CHART)/templates/*.yaml
+docs/$(RELEASE).tgz: $(CHART)/* $(CHART)/*/*
 	$(call banner)
 	helm package $(CHART) -d docs
 
-docs/$(RELEASE_LATEST).tgz: $(CHART)/Chart.yaml $(CHART)/templates/*.yaml
+docs/$(RELEASE_LATEST).tgz: $(CHART)/* $(CHART)/*/*
 	$(call banner)
 	rm -rf build/$(CHART_LATEST)
 	cp -r $(CHART) build/$(CHART_LATEST)

--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -21,26 +21,6 @@ alerting:
       action: keep
 
 scrape_configs:
-  - job_name: prometheus
-    static_configs:
-      - targets:
-        - localhost:9090
-    metric_relabel_configs:
-      - target_label: workload
-        replacement: prometheus-server
-      - source_labels: [__meta_kubernetes_namespace]
-        action: replace
-        target_label: namespace
-      - source_labels: [__meta_kubernetes_service_name]
-        action: replace
-        target_label: kubernetes_name
-      - source_labels: [__meta_kubernetes_pod_node_name]
-        action: replace
-        target_label: node_name
-      - source_labels: [__meta_kubernetes_pod_host_ip]
-        action: replace
-        target_label: node_ip
-{{ .MonitorTypeRules | indent 6 }}
 
   # This uses separate scrape configs for cluster components (i.e. API server, node)
   # and services to allow each to use different authentication configs.

--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -54,6 +54,8 @@ scrape_configs:
     kubernetes_sd_configs:
       - role: node
 
+    honor_labels: true
+
     relabel_configs:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
@@ -105,6 +107,8 @@ scrape_configs:
 
     kubernetes_sd_configs:
       - role: endpoints
+
+    honor_labels: true
 
     relabel_configs:
       - source_labels: [__meta_kubernetes_service_annotation_{{ dot2underscore .PrometheusDomain }}_scrape]
@@ -222,6 +226,8 @@ scrape_configs:
 
     kubernetes_sd_configs:
       - role: pod
+
+    honor_labels: true
 
     relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_{{ dot2underscore .PrometheusDomain }}_scrape]

--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -126,8 +126,9 @@ scrape_configs:
       - action: labelmap
         regex: __meta_kubernetes_service_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
-        action: replace
         target_label: namespace
+      - source_labels: [__meta_kubernetes_namespace]
+        target_label: kubernetes_namespace
       - source_labels: [__meta_kubernetes_service_name]
         action: replace
         target_label: kubernetes_name
@@ -140,27 +141,29 @@ scrape_configs:
 
     # workload labels:
     metric_relabel_configs:
-      - source_labels: [created_by_kind, pod]
-        regex: 'ReplicaSet;(.*)-[^-]+-[^-]+'
+      - source_labels: [created_by_kind, pod, workload]
+        regex: 'ReplicaSet;(.+)-[^-]+-[^-]+;'
         target_label: workload
-      - source_labels: [created_by_kind, pod]
-        regex: 'StatefulSet;(.*)-[^-]+'
+      - source_labels: [created_by_kind, pod, workload]
+        regex: 'StatefulSet;(.+)-[^-]+;'
         target_label: workload
-      - source_labels: [created_by_kind, pod]
-        regex: 'DaemonSet;(.*)-[^-]+'
+      - source_labels: [created_by_kind, pod, workload]
+        regex: 'DaemonSet;(.+)-[^-]+;'
         target_label: workload
-      - source_labels: [created_by_kind, pod]
-        regex: 'Job;(.*)-[^-]+'
+      - source_labels: [created_by_kind, pod, workload]
+        regex: 'Job;(.+)-[^-]+;'
         target_label: workload
-      - source_labels: [created_by_kind, pod]
-        regex: 'ReplicationController;(.*)-[^-]+'
+      - source_labels: [created_by_kind, pod, workload]
+        regex: 'ReplicationController;(.+)-[^-]+;'
         target_label: workload
-      - source_labels: [created_by_kind, pod]
-        regex: '.none.;(.*)'
+      - source_labels: [created_by_kind, pod, workload]
+        regex: '.none.;(.+);'
         target_label: workload
-      - source_labels: [deployment]
+      - source_labels: [deployment, workload]
+        regex: '(.+);'
         target_label: workload
-      - source_labels: [daemonset]
+      - source_labels: [daemonset, workload]
+        regex: '(.+);'
         target_label: workload
 {{ .MonitorTypeRules | indent 6 }}
 
@@ -236,7 +239,6 @@ scrape_configs:
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
-        action: replace
         target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
@@ -247,13 +249,13 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_host_ip]
         action: replace
         target_label: node_ip
-      - source_labels: [__meta_kubernetes_pod_label_pod_template_hash, __meta_kubernetes_pod_name]
+      - source_labels: [__meta_kubernetes_pod_label_pod_template_hash, __meta_kubernetes_pod_name, workload]
         action: replace
-        regex: '[^;]+;(.*)-[^-]+-[^-]+'
+        regex: '[^;]+;(.*)-[^-]+-[^-]+;'
         target_label: workload
-      - source_labels: [__meta_kubernetes_pod_label_statefulset_kubernetes_io_pod_name]
+      - source_labels: [__meta_kubernetes_pod_label_statefulset_kubernetes_io_pod_name, workload]
         action: replace
-        regex: (.*)-[0-9]+
+        regex: '(.*)-[0-9]+;'
         target_label: workload
 
     metric_relabel_configs:

--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -28,6 +28,18 @@ scrape_configs:
     metric_relabel_configs:
       - target_label: workload
         replacement: prometheus-server
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_service_name]
+        action: replace
+        target_label: kubernetes_name
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: node_name
+      - source_labels: [__meta_kubernetes_pod_host_ip]
+        action: replace
+        target_label: node_ip
 {{ .MonitorTypeRules | indent 6 }}
 
   # This uses separate scrape configs for cluster components (i.e. API server, node)
@@ -135,7 +147,7 @@ scrape_configs:
         regex: __meta_kubernetes_service_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_service_name]
         action: replace
         target_label: kubernetes_name
@@ -207,7 +219,7 @@ scrape_configs:
       - action: labelmap
         regex: __meta_kubernetes_service_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_service_name]
         target_label: kubernetes_name
 
@@ -241,7 +253,7 @@ scrape_configs:
         regex: __meta_kubernetes_pod_label_(.+)
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        target_label: kubernetes_namespace
+        target_label: namespace
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: kubernetes_pod_name

--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -178,6 +178,10 @@ scrape_configs:
       - source_labels: [created_by_kind, pod]
         regex: '.none.;(.*)'
         target_label: workload
+      - source_labels: [deployment]
+        target_label: workload
+      - source_labels: [daemonset]
+        target_label: workload
 {{ .MonitorTypeRules | indent 6 }}
 
   - job_name: 'prometheus-pushgateway'

--- a/enterprise-suite/es-monitor-api/static-rules.yml
+++ b/enterprise-suite/es-monitor-api/static-rules.yml
@@ -20,7 +20,7 @@
   expr: rate(kube_pod_container_status_restarts_total[1m]) * on (pod) group_left(workload, monitor_type) kube_pod_info
 
 - record: container_starts_total
-  expr: sum by (workload) (1 + kube_pod_container_status_restarts_total * on (pod) group_left(workload, monitor_type) kube_pod_info)
+  expr: sum by (workload, namespace, monitor_type) (1 + kube_pod_container_status_restarts_total * on (pod) group_left(workload, monitor_type) kube_pod_info)
 
 - record: kube_pod_failed
   expr: kube_pod_status_phase{phase="Failed"} * on (pod) group_left(workload, monitor_type) kube_pod_info
@@ -32,7 +32,7 @@
   expr: avg by (workload, namespace, monitor_type) (label_replace(kube_deployment_metadata_generation - kube_deployment_status_observed_generation, "workload", "$1", "deployment", "(.+)"))
 
 - record: kube_workload_generation_lag
-  expr: avg by (workload, namespace) (label_replace(kube_daemonset_status_desired_number_scheduled - kube_daemonset_status_number_ready, "workload", "$1", "daemonset", "(.+)"))
+  expr: avg by (workload, namespace, monitor_type) (label_replace(kube_daemonset_status_desired_number_scheduled - kube_daemonset_status_number_ready, "workload", "$1", "daemonset", "(.+)"))
 
 - record: prometheus_notification_queue_percent
   expr: 100 * prometheus_notifications_queue_length / prometheus_notifications_queue_capacity
@@ -65,7 +65,7 @@
   expr: sum without (instance) (rate(kafka_server_brokertopicmetrics_messagesin_total[5m]))
 
 - record: kafka_active_controllers
-  expr: sum by (workload, monitor_type) (kafka_controller_kafkacontroller_activecontrollercount)
+  expr: sum by (namespace, workload, monitor_type) (kafka_controller_kafkacontroller_activecontrollercount)
 
 - record: memcached_miss_ratio
   expr: (sum without(command, status) (memcached_commands_total{status="miss"})/sum without(command, status) (memcached_commands_total)) * 100

--- a/enterprise-suite/es-monitor-api/static-rules.yml
+++ b/enterprise-suite/es-monitor-api/static-rules.yml
@@ -29,10 +29,10 @@
   expr: max without (phase) (kube_pod_status_phase{phase=~"Pending|Unknown"} * on (pod) group_left(workload, monitor_type) kube_pod_info)
 
 - record: kube_workload_generation_lag
-  expr: avg by (workload, namespace, monitor_type) (label_replace(kube_deployment_metadata_generation - kube_deployment_status_observed_generation, "workload", "$1", "deployment", "(.+)"))
+  expr: avg by (workload, namespace, monitor_type) (kube_deployment_metadata_generation - kube_deployment_status_observed_generation)
 
 - record: kube_workload_generation_lag
-  expr: avg by (workload, namespace, monitor_type) (label_replace(kube_daemonset_status_desired_number_scheduled - kube_daemonset_status_number_ready, "workload", "$1", "daemonset", "(.+)"))
+  expr: avg by (workload, namespace, monitor_type) (kube_daemonset_status_desired_number_scheduled - kube_daemonset_status_number_ready)
 
 - record: prometheus_notification_queue_percent
   expr: 100 * prometheus_notifications_queue_length / prometheus_notifications_queue_capacity

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -154,6 +154,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-server
+  annotations:
+    {{ .Values.prometheusDomain }}/scrape: "true"
 spec:
   ports:
     - port: 80

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -59,6 +59,9 @@ spec:
       labels:
         app: prometheus
         component: server
+      annotations:
+        {{ .Values.prometheusDomain }}/scrape: "true"
+        {{ .Values.prometheusDomain }}/port: "9090"
     spec:
       serviceAccountName: prometheus-server
 
@@ -154,8 +157,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-server
-  annotations:
-    {{ .Values.prometheusDomain }}/scrape: "true"
 spec:
   ports:
     - port: 80


### PR DESCRIPTION
Rollup prometheus config fixes for various bugs related to namespace relabeling.  This makes namespace labeling consistent, so we have a tuple of namespace, workload, monitor_type hanging off of incoming data in the right way.

fixes lightbend/es-backend#268
fixes lightbend/es-backend#267
fixes lightbend/es-backend#253