### PR TITLE
Move the kubernetes-exporter graphs to cluster-exporter

### DIFF
--- a/enterprise-suite/es-grafana/cluster-exporter.json
+++ b/enterprise-suite/es-grafana/cluster-exporter.json
@@ -1,0 +1,7 @@
+[
+   {"graphName": "CPU Percent", "promQL":["node_cpu_percent"]},
+   {"graphName": "Memory Available Percent", "promQL":["node_memory_usable_percent"]},
+   {"graphName": "File System Free Percent", "promQL":["node_filesystem_free_percent"]},
+   {"graphName": "Bytes Received Per Second", "promQL":["sum by (instance) (irate(node_network_receive_bytes[1m]))"]},
+   {"graphName": "Bytes Transmitted Per Second", "promQL":["sum by (instance) (irate(node_network_transmit_bytes[1m]))"]}
+]

--- a/enterprise-suite/es-grafana/kubernetes-exporter.json
+++ b/enterprise-suite/es-grafana/kubernetes-exporter.json
@@ -1,7 +1,2 @@
 [
-   {"graphName": "CPU Percent", "promQL":["node_cpu_percent"]},
-   {"graphName": "Memory Available Percent", "promQL":["node_memory_usable_percent"]},
-   {"graphName": "File System Free Percent", "promQL":["node_filesystem_free_percent"]},
-   {"graphName": "Bytes Received Per Second", "promQL":["sum by (instance) (irate(node_network_receive_bytes[1m]))"]},
-   {"graphName": "Bytes Transmitted Per Second", "promQL":["sum by (instance) (irate(node_network_transmit_bytes[1m]))"]}
 ]

--- a/enterprise-suite/es-grafana/kubernetes-exporter.json
+++ b/enterprise-suite/es-grafana/kubernetes-exporter.json
@@ -1,2 +1,7 @@
 [
+   {"graphName": "CPU Percent", "promQL":["node_cpu_percent"]},
+   {"graphName": "Memory Available Percent", "promQL":["node_memory_usable_percent"]},
+   {"graphName": "File System Free Percent", "promQL":["node_filesystem_free_percent"]},
+   {"graphName": "Bytes Received Per Second", "promQL":["sum by (instance) (irate(node_network_receive_bytes[1m]))"]},
+   {"graphName": "Bytes Transmitted Per Second", "promQL":["sum by (instance) (irate(node_network_transmit_bytes[1m]))"]}
 ]


### PR DESCRIPTION
As these are cluster level metrics. Kubernetes-exporter should have
container metrics, to be done in
https://github.com/lightbend/es-backend/issues/310.

This will require a change in the console to set `service-type=cluster`
for the top level grafana link.

For https://github.com/lightbend/es-backend/issues/289
For https://github.com/lightbend/es-backend/issues/306