### PR TITLE
Remove default backend config, since it's the default...

### DIFF
--- a/enterprise-suite/tests/resources/ingress-test.template.yaml
+++ b/enterprise-suite/tests/resources/ingress-test.template.yaml
@@ -6,9 +6,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
-  backend:
-    serviceName: default-http-backend
-    servicePort: {{PORT}}
   rules:
   - host: minikube.ingress.test
     http:


### PR DESCRIPTION
This went in to k8s-explore after moving the tests to helm-charts.  (https://github.com/lightbend/k8s-explore/pull/150)  Making the same change again in helm-charts now.

cf. https://github.com/lightbend/k8s-explore/pull/153