### PR TITLE
lighter test app for smoketest

### DIFF
--- a/enterprise-suite/tests/resources/app_with_service.yaml
+++ b/enterprise-suite/tests/resources/app_with_service.yaml
@@ -2,32 +2,33 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: es-demo
+  name: es-test
 spec:
   replicas: 2
   template:
     metadata:
       labels:
-        app: es-demo
+        app: es-test
     spec:
       containers:
-        - name: es-demo
-          image: lightbend-docker-registry.bintray.io/enterprise-suite/es-demo:v0.0.1
+        # source: https://github.com/lightbend/k8s-explore/tree/master/query/nan
+        - name: es-test
+          image: lightbend-docker-registry.bintray.io/enterprise-suite/es-test:v1
           imagePullPolicy: IfNotPresent
           ports:
-            - containerPort: 9001
+            - containerPort: 8080
               name: metrics
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: es-demo
+  name: es-test
   annotations:
     prometheus.io/scrape: "true"
 spec:
   ports:
     - port: 80
-      targetPort: 9001
+      targetPort: 8080
   selector:
-    app: es-demo
+    app: es-test
 

--- a/enterprise-suite/tests/smoke_prometheus
+++ b/enterprise-suite/tests/smoke_prometheus
@@ -218,7 +218,7 @@ T $? 'node-exporter "err" logs'
 
 # app tests
 
-app_instances='count( sum by (instance) (akka_actor_running_actors{workload="es-demo", namespace="default"}) )  == 2'
+app_instances='count( count by (instance) (ohai{workload="es-test", namespace="default"}) ) == 2'
 app_data() {
   results=$( prom_query "$app_instances" | jq '.data.result | length' )
   ! [[ results -eq 0 ]]


### PR DESCRIPTION
This uses es-test instead of es-demo.  es-test is a tiny distroless go
app that does nothing but produce "ohai" metrics for prometheus.
es-demo is an akka app and has been seen to take over a minute to start
on Travis.  Hopefully this is faster!