### PR TITLE
WIP Slack msg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,5 @@ notifications:
   email: false
   slack:
     secure: Wbp33+rhtKSkDQsoBq33b3/WFk7/vzoKNqVoGhjFyXtBTE/mP/C7ZvGDxSWVLhbKTqCzlXpp3BlO9/g2PJa3GafssYr+ZRxYzkyXqQnjIUTFylSqKZky729LTtE8eBfreyjX1JZgVu0++kQTkUsQCjBEW0dhZsVSnd8QAQwQQigxue9/wPiZABOuoaZ4UCPoE7EzhRH86MO3RhRdfIMSOwj94cPf95NtN292jmOEsTCayc+CVfJ77wbbANAvqX2kBaBQTgREUk/0guR8bVTO8YxExuYkNEeQZRKa8TLjP9A3Gkd/JED6R3FLLw7EcT9J62zWLTKZqRKCb+Nhc01uy67/m21bVlHfphPgNAy3rU27lmVqzS0NCyiqix8uenoewjFYYbR8+3nTO+kuqeP/lRUmmINkzornICtx+POP+mGOSE4llmplZIhJKWBN1x/OtY9XvIXd1WcZtWnk310zurCN+0qjBIewjs4a28ZcZdB8e/si+Cx5YT2UvXgYZipjM3CX29AaPaCGsuGdjQJN/OFzYbwiJbvfI/O9OEl32aMfu1w4P3WtLNVT2eW6Kdu0HJaRKvtSwzKBmYP8b5xdTQemsG2R97rPN1uTOwVWwviOQgg/pycIxjNawMf6s+5I7CK3zO3QjwrfWSq7d8Nm2qC5J+82+rQSZ6YDr3wJliI=
+    template:
+      - "Build <%{build_url}|#%{build_number}> (<%{compare_url}|%{commit}>) of %{repository_slug}@%{branch} by %{author} %{result} in %{elapsed_time}"


### PR DESCRIPTION
Fix slack message to use `elapsed_time` instead of total `duration` of all builds in matrix.

Since can only specify one template for all types of builds, using the lowest common denominator branch build template as a starting point.  This means it does not mention PR numbers, but the commit link will still take you to the PR on those builds.

https://docs.travis-ci.com/user/notifications/#customizing-slack-notifications