### PR TITLE
DO NOT MERGE [es-backend/issues/227] Disable minikube by default and add NOTEST.tx…

### DIFF
--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -4,9 +4,6 @@ CHART ?= enterprise-suite
 RELEASE_NAME = es
 NAMESPACE = lightbend
 
-# Install minikube-related services.  These are disabled by default.
-MINIKUBE=true
-
 define banner
 	$(info === $@)
 endef
@@ -50,11 +47,6 @@ init:
 	@$(SCRIPTS_DIR)/lib.sh
 	@helm init -c > /dev/null
 
-$(HELM_CHARTS_DIR)/docs/$(RELEASE_NAME)/$(ALL_YAML): $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz
-	$(call banner)
-	mkdir -p $(HELM_CHARTS_DIR)/docs/$(RELEASE_NAME)
-	helm --namespace=$(NAMESPACE) template $< > $@
-
 # Note: This works for enterprise-suite and allows us to define a latest-specific version in enterprise-suite-latest
 $(HELM_CHARTS_DIR)/docs/$(filter-out %-latest,$(CHART))-$(VERSION).tgz: $(COMPONENTS) $(SUBCOMPONENTS)
 	$(call banner)
@@ -77,6 +69,15 @@ clean::  ## Delete make artifacts
 
 ## These targets used for dev work
 #
+
+# Install minikube-related services.  These are disabled by default but we enable for debugging purposes.
+# (If desired, you can override with "make <target> MINIKUBE=false")
+MINIKUBE=true
+
+$(HELM_CHARTS_DIR)/docs/$(RELEASE_NAME)/$(ALL_YAML): $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz
+	$(call banner)
+	mkdir -p $(HELM_CHARTS_DIR)/docs/$(RELEASE_NAME)
+	helm --namespace=$(NAMESPACE) template $< --set minikube=$(MINIKUBE) > $@
 
 install-helm:  ## Install required helm components into cluster
 	-kubectl create serviceaccount --namespace kube-system tiller

--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -4,6 +4,9 @@ CHART ?= enterprise-suite
 RELEASE_NAME = es
 NAMESPACE = lightbend
 
+# Install minikube-related services.  These are disabled by default.
+MINIKUBE=true
+
 define banner
 	$(info === $@)
 endef
@@ -84,7 +87,7 @@ delete-local:  ## Delete chart from cluster with helm
 	-helm delete --purge $(RELEASE_NAME)
 
 install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm delete-local  ## Install local chart
-	helm install $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz --name=$(RELEASE_NAME) --namespace=$(NAMESPACE) --debug --wait
+	helm install $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz --name=$(RELEASE_NAME) --namespace=$(NAMESPACE) --debug --wait --set minikube=$(MINIKUBE)
 
 #
 ##

--- a/enterprise-suite/README.md
+++ b/enterprise-suite/README.md
@@ -6,16 +6,33 @@ Helm chart setup for the Enterprise Suite project.
 
 ## Helm install enterprise suite:
 
-See ../README.md for instruction on how to install Enterprise Suite.
+See ../README.md for general instructions for installing chart as these are applicable to the installation of Enterprise Suite as well.
+In the normal case use
+
+```bash
+helm install lightbend-helm-charts/enterprise-suite --name=es --namespace=lightbend --debug
+```
+
+To run Enterprise Suite in a minikube environment, instead use
+
+```bash
+helm install lightbend-helm-charts/enterprise-suite --name=es --namespace=lightbend --debug --set minikube=true
+```
 
 ## "latest" internal dev release:
 
 By default all the helm charts use versioned images, so you are using fixed dependencies.
-There is also a special "latest" chart which uses "latest" tags for images. This is
+Enterprise Suite also has a special "latest" chart which uses "latest" tags for images. This is
 useful for development.
 
 ```bash
 helm install lightbend-helm-charts/enterprise-suite-latest --name=es --namespace=lightbend --debug
+```
+
+To work with minikube, instead install with:
+
+```bash
+helm install lightbend-helm-charts/enterprise-suite-latest --name=es --namespace=lightbend --debug --set minikube=true
 ```
 
 When PRs are merged to master, "latest" is updated automatically.  If you have installed the  `lightbend-helm-charts/enterprise-suite-latest` helm chart or  `es/all-latest.yaml` you should be able to simply delete the pod you want upgraded and minikube will go fetch the latest from bintray and install it for you.  You will only have to do a helm upgrade on this track if you want to pick up configuration changes in the helm chart itself.
@@ -30,7 +47,14 @@ helm upgrade lightbend-helm-charts/enterprise-suite --name=es --namespace=lightb
 helm upgrade lightbend-helm-charts/enterprise-suite-latest --name=es --namespace=lightbend --debug
 ```
 
+If using minikube, include the following option in the `upgrade` command:
+```
+set minikube=true
+```
+
 ## kubectl apply enterprise suite:
+
+_This option will likely disappear in the future._
 
 ```
 kubectl create namespace lightbend
@@ -40,6 +64,8 @@ kubectl --namespace=lightbend apply -f https://lightbend.github.io/helm-charts/e
 # or use "latest" container images
 kubectl --namespace=lightbend apply -f https://lightbend.github.io/helm-charts/es/all-latest.yaml
 ```
+
+These assume you're using minikube.
 
 ## Cutting a Release / Publishing Charts
 

--- a/enterprise-suite/templates/NOTES.txt
+++ b/enterprise-suite/templates/NOTES.txt
@@ -1,0 +1,11 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get {{ .Release.Name }}
+
+If you want to run {{ .Release.Name }} with exposed services, appropriate only for a minikube environment, reinstall the chart, specifying minikube=true.  e.g.
+  $ helm install .../{{ .Chart.Name }}.tgz --name=es --namespace=lightbend --debug --wait --set minikube=true

--- a/enterprise-suite/templates/NOTES.txt
+++ b/enterprise-suite/templates/NOTES.txt
@@ -8,4 +8,4 @@ To learn more about the release, try:
   $ helm get {{ .Release.Name }}
 
 If you want to run {{ .Release.Name }} with exposed services, appropriate only for a minikube environment, reinstall the chart, specifying minikube=true.  e.g.
-  $ helm install .../{{ .Chart.Name }}.tgz --name=es --namespace=lightbend --debug --wait --set minikube=true
+  $ helm install lightbend-helm-charts/{{ .Chart.Name }} --name=es --namespace=lightbend --debug --wait --set minikube=true

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -26,8 +26,8 @@ nodeExporterVersion: v0.15.2
 imagePullPolicy: IfNotPresent
 # prometheus annotation domain, e.g. `domain/scrape=true`
 prometheusDomain: prometheus.io
-# minikube debug resources
-minikube: true
+# include minikube debug resources
+minikube: false
 
 #################################################
 # ResourceRequests

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -26,7 +26,7 @@ nodeExporterVersion: v0.15.2
 imagePullPolicy: IfNotPresent
 # prometheus annotation domain, e.g. `domain/scrape=true`
 prometheusDomain: prometheus.io
-# include minikube debug resources
+# include minikube debug resources?
 minikube: false
 
 #################################################


### PR DESCRIPTION
…t for helm install

This disables, by default, the minikube-specific helm-charts mods.  (Which are essentially mods to expose our services with NodePorts.)

This is marked as DO NOT MERGE for now because this change will undoubtedly throw our current users for a loop.  We'll have to prepare them via email etc. that this is coming.