### PR TITLE
default resource requests

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -53,6 +53,10 @@ spec:
       containers:
         - name: prometheus-alertmanager
           image: prom/alertmanager:{{ .Values.alertManagerVersion }}
+          resources:
+            requests:
+              cpu: {{ default .Values.defaultCPURequest .Values.alertManagerCPURequest }}
+              memory: {{ default .Values.defaultMemoryRequest .Values.alertManagerMemoryRequest }}
           env:
           args:
             - --config.file=/etc/config/alertmanager.yml
@@ -78,6 +82,10 @@ spec:
 
         - name: prometheus-alertmanager-configmap-reload
           image: jimmidyson/configmap-reload:{{ .Values.configMapReloadVersion }}
+          resources:
+            requests:
+              cpu: {{ default .Values.defaultCPURequest .Values.configmapReloadCPURequest }}
+              memory: {{ default .Values.defaultMemoryRequest .Values.configmapReloadMemoryRequest }}
           args:
             - --volume-dir=/etc/config
             - --webhook-url=http://localhost:9093/-/reload

--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -14,6 +14,10 @@ spec:
       - name: es-console
         image: lightbend-docker-registry.bintray.io/enterprise-suite/es-console:{{ .Values.esConsoleVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
+        resources:
+          requests:
+            cpu: {{ default .Values.defaultCPURequest .Values.esConsoleCPURequest }}
+            memory: {{ default .Values.defaultMemoryRequest .Values.esConsoleMemoryRequest }}
         ports:
         - containerPort: 80
         volumeMounts:

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -100,6 +100,10 @@ spec:
       - image: lightbend-docker-registry.bintray.io/enterprise-suite/es-grafana:{{ .Values.esGrafanaVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         name: grafana-server
+        resources:
+          requests:
+            cpu: {{ default .Values.defaultCPURequest .Values.esGrafanaCPURequest }}
+            memory: {{ default .Values.defaultMemoryRequest .Values.esGrafanaMemoryRequest }}
         env:
           # The following env variables set up anonymous access to grafana with editor access.
           - name: GF_AUTH_ANONYMOUS_ENABLED

--- a/enterprise-suite/templates/kube-state-metrics.yaml
+++ b/enterprise-suite/templates/kube-state-metrics.yaml
@@ -82,7 +82,11 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "gcr.io/google_containers/kube-state-metrics:v1.2.0"
+          image: "gcr.io/google_containers/kube-state-metrics:{{ .Values.kubeStateMetricsVersion }}"
+          resources:
+            requests:
+              cpu: {{ default .Values.defaultCPURequest .Values.kubeStateMetricsCPURequest }}
+              memory: {{ default .Values.defaultMemoryRequest .Values.kubeStateMetricsMemoryRequest }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/enterprise-suite/templates/node-exporter.yaml
+++ b/enterprise-suite/templates/node-exporter.yaml
@@ -23,7 +23,11 @@ spec:
       serviceAccountName: "default"
       containers:
         - name: prometheus-node-exporter
-          image: "prom/node-exporter:v0.15.2"
+          image: "prom/node-exporter:{{ .Values.nodeExporterVersion }}"
+          resources:
+            requests:
+              cpu: {{ default .Values.defaultCPURequest .Values.nodeExporterCPURequest }}
+              memory: {{ default .Values.defaultMemoryRequest .Values.nodeExporterMemoryRequest }}
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -68,6 +68,10 @@ spec:
       initContainers:
         - name: setup
           image: alpine
+          resources:
+            requests:
+              cpu: {{ default .Values.defaultCPURequest }}
+              memory: {{ default .Values.defaultMemoryRequest }}
           command:
             - /bin/sh
             - -c
@@ -84,6 +88,10 @@ spec:
         - name: es-monitor-api
           image: lightbend-docker-registry.bintray.io/enterprise-suite/es-monitor-api:{{ .Values.esMonitorVersion }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          resources:
+            requests:
+              cpu: {{ default .Values.defaultCPURequest .Values.esMonitorCPURequest }}
+              memory: {{ default .Values.defaultMemoryRequest .Values.esMonitorMemoryRequest }}
           args:
             - --configPath=/etc/config/
             - --storagePath=/monitor-data/
@@ -116,6 +124,10 @@ spec:
 
         - name: prometheus-server
           image: prom/prometheus:{{ .Values.prometheusVersion }}
+          resources:
+            requests:
+              cpu: {{ default .Values.defaultCPURequest .Values.prometheusCPURequest }}
+              memory: {{ default .Values.defaultMemoryRequest .Values.prometheusMemoryRequest }}
           args:
             - --config.file=/etc/config/prometheus.yml
             - --web.console.libraries=/etc/prometheus/console_libraries

--- a/enterprise-suite/templates/resourcelimits.yaml
+++ b/enterprise-suite/templates/resourcelimits.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: {{.Release.Namespace}}-namespace-defaults
+spec:
+  limits:
+  - defaultRequest:
+      cpu: {{ .Values.defaultCPURequest }}
+      memory: {{ .Values.defaultMemoryRequest }}
+    type: Container

--- a/enterprise-suite/templates/resourcelimits.yaml
+++ b/enterprise-suite/templates/resourcelimits.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: LimitRange
 metadata:
-  name: {{.Release.Namespace}}-namespace-defaults
+  name: {{ .Release.Namespace }}-namespace-defaults
 spec:
   limits:
   - defaultRequest:

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -13,6 +13,11 @@ prometheusVersion: v2.2.1
 alertManagerVersion: v0.15.1
 # jimmidyson/configmap-reload
 configMapReloadVersion: v0.2.2
+# gcr.io/google_containers/kube-state-metrics
+kubeStateMetricsVersion: v1.2.0
+# prom/node-exporter
+nodeExporterVersion: v0.15.2
+
 
 #################################################
 # Settings
@@ -23,3 +28,11 @@ imagePullPolicy: IfNotPresent
 prometheusDomain: prometheus.io
 # minikube debug resources
 minikube: true
+
+#################################################
+# ResourceRequests
+#
+# default container resource requests for CPU (0.1)
+defaultCPURequest: 100m
+# default container resource requests for memory
+defaultMemoryRequest: 256Mi


### PR DESCRIPTION
part of lightbend/es-backend#224

defaultCPURequests     1/10th of a cpu
defaultMemoryRequests  256 meg

used as the default for every container.  Excluding init containers,
every container has a fine grained helm option for CPU and Memory.

alertManager
configmapReload
esConsole
esGrafana
kubeStateMetrics
nodeExporter
esMonitor
prometheus

in case someone wants to override the default in a specific instance.