### PR TITLE
Support multiple pod scrape ports

### DIFF
--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -240,7 +240,7 @@ scrape_configs:
   #
   # * `{{ .PrometheusDomain }}/scrape`: Only scrape pods that have a value of `true`
   # * `{{ .PrometheusDomain }}/path`: If the metrics path is not `/metrics` override this.
-  # * `{{ .PrometheusDomain }}/port`: Scrape the pod on the indicated port instead of the default of `9102`.
+  # * `{{ .PrometheusDomain }}/port`: Scrape the pod on the indicated port instead of all ports by default.
   - job_name: 'kubernetes-pods'
 
     kubernetes_sd_configs:
@@ -249,35 +249,60 @@ scrape_configs:
     honor_labels: true
 
     relabel_configs:
+
+      # Only scrape pods with prometheus.io/scrape=true.
       - source_labels: [__meta_kubernetes_pod_annotation_{{ dot2underscore .PrometheusDomain }}_scrape]
         action: keep
         regex: true
+
+      # Set scrape path from prometheus.io/path.
       - source_labels: [__meta_kubernetes_pod_annotation_{{ dot2underscore .PrometheusDomain }}_path]
         action: replace
         target_label: __metrics_path__
         regex: (.+)
+
+      # Keep only the ports ending in the suffix `metrics` if prometheus.io/port is unspecified.
+      - source_labels: [__meta_kubernetes_pod_annotation_{{ dot2underscore .PrometheusDomain }}_port, __meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: ^(.+;.*)|(;.*metrics)$
+
+      # Set port from prometheus.io/port.
       - source_labels: [__address__, __meta_kubernetes_pod_annotation_{{ dot2underscore .PrometheusDomain }}_port]
         action: replace
         regex: (.+):(?:\d+);(\d+)
         replacement: ${1}:${2}
         target_label: __address__
+
+      # Copy all labels from the pod to the scraped metrics.
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
+
+      # Set the namespace label from metadata.
       - source_labels: [__meta_kubernetes_namespace]
         target_label: namespace
+
+      # Set the kubernetes_pod_name label from metadata.
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: kubernetes_pod_name
+
+      # Set the node_name label from metadata.
       - source_labels: [__meta_kubernetes_pod_node_name]
         action: replace
         target_label: node_name
+
+      # Set the node_ip label from metadata.
       - source_labels: [__meta_kubernetes_pod_host_ip]
         action: replace
         target_label: node_ip
+
+      # Set the workload label from pod name.
       - source_labels: [__meta_kubernetes_pod_label_pod_template_hash, __meta_kubernetes_pod_name, es_workload]
         action: replace
         regex: '[^;]+;(.*)-[^-]+-[^-]+;'
         target_label: es_workload
+
+      # Set the workload label from statefulset if pod name was unable to set it.
       - source_labels: [__meta_kubernetes_pod_label_statefulset_kubernetes_io_pod_name, es_workload]
         action: replace
         regex: '(.*)-[0-9]+;'

--- a/enterprise-suite/tests/resources/app.yaml
+++ b/enterprise-suite/tests/resources/app.yaml
@@ -2,13 +2,16 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: es-test-via-service
+  name: es-test
 spec:
   replicas: 2
   template:
     metadata:
       labels:
         app: es-test
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
     spec:
       containers:
         # source: https://github.com/lightbend/k8s-explore/tree/master/query/nan
@@ -18,16 +21,3 @@ spec:
           ports:
             - containerPort: 8080
               name: metrics
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: es-test-via-service
-  annotations:
-    prometheus.io/scrape: "true"
-spec:
-  ports:
-    - port: 80
-      targetPort: 8080
-  selector:
-    app: es-test

--- a/enterprise-suite/tests/resources/app_with_multiple_ports.yaml
+++ b/enterprise-suite/tests/resources/app_with_multiple_ports.yaml
@@ -2,32 +2,31 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: es-test-via-service
+  name: es-test-with-multiple-ports
 spec:
   replicas: 2
   template:
     metadata:
       labels:
         app: es-test
+      annotations:
+        prometheus.io/scrape: "true"
     spec:
       containers:
         # source: https://github.com/lightbend/k8s-explore/tree/master/query/nan
-        - name: es-test
+        - name: es-test-1
           image: lightbend-docker-registry.bintray.io/enterprise-suite/es-test:v1
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
               name: metrics
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: es-test-via-service
-  annotations:
-    prometheus.io/scrape: "true"
-spec:
-  ports:
-    - port: 80
-      targetPort: 8080
-  selector:
-    app: es-test
+
+        - name: es-test-2
+          image: lightbend-docker-registry.bintray.io/enterprise-suite/es-test:v1
+          command:
+            - /app
+            - -listen-address=:8081
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8081
+              name: second-metrics

--- a/enterprise-suite/tests/smoke_prometheus
+++ b/enterprise-suite/tests/smoke_prometheus
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -u
 
 # A collection of prometheus-related smoke tests
 
@@ -8,9 +8,11 @@ source smokecommon
 # launch test apps
 #
 
+set -e
 for app in resources/app*.yaml; do
   kubectl apply -f "$app"
 done
+set +e
 
 #
 # prometheus fetchers
@@ -223,6 +225,7 @@ T $? 'node-exporter "err" logs'
 
 # app tests
 
+# app via 'Pod' service discovery
 app_instances='count( count by (instance) (ohai{es_workload="es-test", namespace="default"}) ) == 2'
 app_data() {
   results=$( prom_query "$app_instances" | jq '.data.result | length' )
@@ -231,6 +234,26 @@ app_data() {
 busy_wait app_data
 
 prom_has_data "$app_instances"
+
+# app via 'Pod' service discovery with multiple metric ports
+app_instances_with_multiple_ports='count( count by (instance) (ohai{es_workload="es-test-with-multiple-ports", namespace="default"}) ) == 4'
+app_data_with_multiple_ports() {
+  results=$( prom_query "$app_instances_with_multiple_ports" | jq '.data.result | length' )
+  ! [[ results -eq 0 ]]
+}
+busy_wait app_data_with_multiple_ports
+
+prom_has_data "$app_instances_with_multiple_ports"
+
+# app via 'Service' service discovery
+app_instances_via_service='count( count by (instance) (ohai{es_workload="es-test-via-service", namespace="default"}) ) == 2'
+app_data_via_service() {
+  results=$( prom_query "$app_instances_via_service" | jq '.data.result | length' )
+  ! [[ results -eq 0 ]]
+}
+busy_wait app_data_via_service
+
+prom_has_data "$app_instances_via_service"
 
 # clean up apps
 


### PR DESCRIPTION
If `prometheus.io/port` is unspecified, named ports ending in `-metrics`
will be scraped.
    
Also add some documentation to the pod relabeling rules so it's easier
to figure out for next time.
