### PR TITLE
shrink default mem, except prometheus

### DIFF
--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -35,4 +35,6 @@ minikube: true
 # default container resource requests for CPU (0.1)
 defaultCPURequest: 100m
 # default container resource requests for memory
-defaultMemoryRequest: 256Mi
+defaultMemoryRequest: 50Mi
+# Prometheus resource request for memory
+prometheusMemoryRequest: 250Mi


### PR DESCRIPTION
Setting to 50M per recommendation from @jsravn

On a single node minikube install doing nothing, max memory usage is

kube-state:  19M
node-exporter: 8M
prometheus: 204M
alert-manager: 8M
es-console: 2M
grafana: 33M

and container_spec_cpu_shares is near zero.  Prometheus and Alertmanager are 4.
