### PR TITLE
Fix helm-charts to support minishift

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -79,6 +79,8 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
+            - name: data-volume
+              mountPath: /data
 
         - name: prometheus-alertmanager-configmap-reload
           image: jimmidyson/configmap-reload:{{ .Values.configMapReloadVersion }}
@@ -93,10 +95,13 @@ spec:
             - name: config-volume
               mountPath: /etc/config
               readOnly: true
+
       volumes:
         - name: config-volume
           configMap:
             name: prometheus-alertmanager
+        - name: data-volume
+          emptydir: {}
 
 {{ if .Values.minikube }}
 ---

--- a/enterprise-suite/templates/kube-state-metrics.yaml
+++ b/enterprise-suite/templates/kube-state-metrics.yaml
@@ -83,6 +83,9 @@ spec:
       containers:
         - name: prometheus-kube-state-metrics
           image: "gcr.io/google_containers/kube-state-metrics:{{ .Values.kubeStateMetricsVersion }}"
+          args:
+            - --port=8080
+            - --telemetry-port=8081
           resources:
             requests:
               cpu: {{ default .Values.defaultCPURequest .Values.kubeStateMetricsCPURequest }}

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -130,6 +130,7 @@ spec:
               memory: {{ default .Values.defaultMemoryRequest .Values.prometheusMemoryRequest }}
           args:
             - --config.file=/etc/config/prometheus.yml
+            - --storage.tsdb.path=/data
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --web.enable-lifecycle
@@ -150,6 +151,8 @@ spec:
             - name: config-volume
               mountPath: /etc/config
               readOnly: true
+            - name: prometheus-data-volume
+              mountPath: /data
 
       terminationGracePeriodSeconds: 300
       volumes:
@@ -159,6 +162,8 @@ spec:
           configMap:
             name: es-monitor-api
         - name: monitor-data-volume
+          emptyDir: {}
+        - name: prometheus-data-volume
           emptyDir: {}
         - name: bare-prometheus
           configMap:


### PR DESCRIPTION
* Use a data volume for prometheus.
* Use a data volume for alertmanager.
* Use non privileged ports for kube-state-metrics.

for https://github.com/lightbend/es-backend/issues/331