### PR TITLE
Fix tests to work in minishift environment

### DIFF
--- a/enterprise-suite/tests/smoke_ingress
+++ b/enterprise-suite/tests/smoke_ingress
@@ -5,6 +5,7 @@
 #set -x
 
 source smokecommon
+if [[ $CURRENT_CONTEXT == "minishift" ]]; then exit 0; fi
 
 TMPPIPE=$(mktemp -t pipe.XXX)
 

--- a/enterprise-suite/tests/smoke_ingress-tls
+++ b/enterprise-suite/tests/smoke_ingress-tls
@@ -12,6 +12,7 @@
 # need to deal with the secrets too
 
 source smokecommon
+if [[ $CURRENT_CONTEXT == "minishift" ]]; then exit 0; fi
 
 TMPFILE=$(mktemp -t pipe.XXX)
 

--- a/enterprise-suite/tests/smoke_prometheus
+++ b/enterprise-suite/tests/smoke_prometheus
@@ -10,7 +10,7 @@ source smokecommon
 
 set -e
 for app in resources/app*.yaml; do
-  kubectl apply -f "$app"
+  kubectl apply -f "$app" -n lightbend
 done
 set +e
 
@@ -18,10 +18,7 @@ set +e
 # prometheus fetchers
 #
 
-prom() {
-  minikube service --namespace=lightbend --url expose-prometheus
-}
-PROM=$( busy_wait prom )
+PROM=$( busy_wait nodeport expose-prometheus)
 
 prom_query() {
   curl -fsG "$PROM/api/v1/query" --data-urlencode "query=$*"
@@ -224,9 +221,8 @@ T $? 'node-exporter "warn" logs'
 T $? 'node-exporter "err" logs'
 
 # app tests
-
 # app via 'Pod' service discovery
-app_instances='count( count by (instance) (ohai{es_workload="es-test", namespace="default"}) ) == 2'
+app_instances='count( count by (instance) (ohai{es_workload="es-test", namespace="lightbend"}) ) == 2'
 app_data() {
   results=$( prom_query "$app_instances" | jq '.data.result | length' )
   ! [[ results -eq 0 ]]
@@ -236,7 +232,7 @@ busy_wait app_data
 prom_has_data "$app_instances"
 
 # app via 'Pod' service discovery with multiple metric ports
-app_instances_with_multiple_ports='count( count by (instance) (ohai{es_workload="es-test-with-multiple-ports", namespace="default"}) ) == 4'
+app_instances_with_multiple_ports='count( count by (instance) (ohai{es_workload="es-test-with-multiple-ports", namespace="lightbend"}) ) == 4'
 app_data_with_multiple_ports() {
   results=$( prom_query "$app_instances_with_multiple_ports" | jq '.data.result | length' )
   ! [[ results -eq 0 ]]
@@ -246,7 +242,7 @@ busy_wait app_data_with_multiple_ports
 prom_has_data "$app_instances_with_multiple_ports"
 
 # app via 'Service' service discovery
-app_instances_via_service='count( count by (instance) (ohai{es_workload="es-test-via-service", namespace="default"}) ) == 2'
+app_instances_via_service='count( count by (instance) (ohai{es_workload="es-test-via-service", namespace="lightbend"}) ) == 2'
 app_data_via_service() {
   results=$( prom_query "$app_instances_via_service" | jq '.data.result | length' )
   ! [[ results -eq 0 ]]
@@ -258,7 +254,7 @@ prom_has_data "$app_instances_via_service"
 # clean up apps
 
 for app in resources/app*.yaml; do
-  kubectl delete -f "$app"
+  kubectl delete -f "$app" -n lightbend
 done
 
 test_summary

--- a/enterprise-suite/tests/smokecommon
+++ b/enterprise-suite/tests/smokecommon
@@ -9,6 +9,8 @@
 set -o pipefail
 set -o nounset
 
+: "${CURRENT_CONTEXT:=minikube}"
+
 # error msg
 # print msg to stderr and exit with error
 error() {
@@ -65,7 +67,11 @@ test_summary() {
 # Get URL for NodePort assignment
 # nodeport <name>
 nodeport() {
-  minikube service --namespace=lightbend --url $1
+  if [[ $CURRENT_CONTEXT == "minishift" ]]; then
+    oc get route -o json  | jq ".items[]|select(.metadata.name==\"$1\")|.spec.host" | tr -d '"'
+  else
+    minikube service --namespace=lightbend --url $1
+  fi
 }
 
 # curl_query <baseURL> <URI> [<curl-opt>...]


### PR DESCRIPTION
Introduce CURRENT_CONTEXT to identify context 

>> for smoke_prometheus apply resources in lightbend namespace instead of default 
a)  minishift has no concept of default namespace 
b) smoke_prometheus also fails  when you use kubens lightbend 

>> disable ingress tests in minishift context
a) There is no ingress controller 
b) oc expose service and port-forward are recommended 
https://docs.okd.io/latest/minishift/openshift/exposing-services.html

lightbend/es-backend/issues/320