### PR TITLE
Allow setting podUID to run as non-root

### DIFF
--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -90,8 +90,9 @@ install-helm:  ## Install required helm components into cluster
 delete-local:  ## Delete chart from cluster with helm
 	-helm delete --purge $(RELEASE_NAME)
 
-install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm delete-local  ## Install local chart
-	helm install $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz --name=$(RELEASE_NAME) --namespace=$(NAMESPACE) --debug --wait --set minikube=$(MINIKUBE)
+install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm delete-local  ## Install local chart, used by smoketests.
+	# We set a podUID here for test purposes to ensure everything works as non-root.
+	helm install $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz --name=$(RELEASE_NAME) --namespace=$(NAMESPACE) --debug --wait --set minikube=$(MINIKUBE),podUID=10001
 
 #
 ##

--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -49,6 +49,10 @@ spec:
         app: prometheus
         component: alertmanager
     spec:
+      {{ if .Values.podUID }}
+      securityContext:
+        runAsUser: {{ .Values.podUID }}
+      {{ end }}
       serviceAccountName: default
       containers:
         - name: prometheus-alertmanager

--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -10,6 +10,10 @@ spec:
       labels:
         run: es-console
     spec:
+      {{ if .Values.podUID }}
+      securityContext:
+        runAsUser: {{ .Values.podUID }}
+      {{ end }}
       containers:
       - name: es-console
         image: lightbend-docker-registry.bintray.io/enterprise-suite/es-console:{{ .Values.esConsoleVersion }}

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -96,6 +96,10 @@ spec:
         app: grafana
         component: server
     spec:
+      {{ if .Values.podUID }}
+      securityContext:
+        runAsUser: {{ .Values.podUID }}
+      {{ end }}
       containers:
       - image: lightbend-docker-registry.bintray.io/enterprise-suite/es-grafana:{{ .Values.esGrafanaVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/enterprise-suite/templates/kube-state-metrics.yaml
+++ b/enterprise-suite/templates/kube-state-metrics.yaml
@@ -79,6 +79,10 @@ spec:
         app: prometheus
         component: kube-state-metrics
     spec:
+      {{ if .Values.podUID }}
+      securityContext:
+        runAsUser: {{ .Values.podUID }}
+      {{ end }}
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics

--- a/enterprise-suite/templates/node-exporter.yaml
+++ b/enterprise-suite/templates/node-exporter.yaml
@@ -21,6 +21,10 @@ spec:
         component: node-exporter
     spec:
       serviceAccountName: "default"
+      {{ if .Values.podUID }}
+      securityContext:
+        runAsUser: {{ .Values.podUID }}
+      {{ end }}
       containers:
         - name: prometheus-node-exporter
           image: "prom/node-exporter:{{ .Values.nodeExporterVersion }}"

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -65,6 +65,11 @@ spec:
     spec:
       serviceAccountName: prometheus-server
 
+      {{ if .Values.podUID }}
+      securityContext:
+        runAsUser: {{ .Values.podUID }}
+      {{ end }}
+
       initContainers:
         - name: setup
           image: alpine

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -28,6 +28,8 @@ imagePullPolicy: IfNotPresent
 prometheusDomain: prometheus.io
 # include minikube debug resources?
 minikube: false
+# Run pods as the given UID. There is no sensible default for this, so customers need to provide it.
+podUID:
 
 #################################################
 # ResourceRequests


### PR DESCRIPTION
By default it is unset, as there is no sensible default for this.

We set it in our smoketests however, so we can verify all our pods can
run as non-root to support Openshift.

part of https://github.com/lightbend/es-backend/issues/331