### PR TITLE
Update generated Kafka and ZK metrics

### DIFF
--- a/enterprise-suite/es-grafana/kafka-exporter.json
+++ b/enterprise-suite/es-grafana/kafka-exporter.json
@@ -1,0 +1,23 @@
+[
+  {"graphName":"Brokers Online", "promQL":["count(kafka_server_replicamanager_leadercount{ContextTags})"]},
+  {"graphName":"Active Controllers", "promQL":["sum(kafka_controller_kafkacontroller_activecontrollercount{ContextTags})"]},
+  {"graphName":"Unclean Leader Election Rate", "promQL":["sum(rate(kafka_controller_controllerstats_uncleanleaderelections_total{ContextTags}[5m]))"]},
+  {"graphName":"Online Partitions", "promQL":["sum(kafka_server_replicamanager_partitioncount{ContextTags})"]},
+  {"graphName":"Under Replicated Partitions", "promQL":["sum(kafka_server_replicamanager_underreplicatedpartitions{ContextTags})"]},
+  {"graphName":"Offline Partitions Count", "promQL":["sum(kafka_controller_kafkacontroller_offlinepartitionscount{ContextTags})"]},
+  {"graphName":"Bytes Rate (In & Out)", "promQL":[
+    "sum(irate(kafka_server_brokertopicmetrics_bytesin_total{ContextTags,topic=\"\"}[1m]))",
+    "sum(irate(kafka_server_brokertopicmetrics_bytesout_total{ContextTags,topic=\"\"}[1m]))"
+  ]},
+  {"graphName":"Total Messages In", "promQL":["sum(irate(kafka_server_brokertopicmetrics_messagesin_total{ContextTags,topic=\"\"}[1m]))"]},
+  {"graphName":"Produce Request Rate (Total & Failed)", "promQL":[
+    "sum(irate(kafka_server_brokertopicmetrics_totalproducerequests_total{ContextTags,topic=\"\"}[1m]))",
+    "sum(irate(kafka_server_brokertopicmetrics_failedproducerequests_total{ContextTags,topic=\"\"}[1m]))"
+  ]},
+  {"graphName":"Fetch Request Rate (Total & Failed)", "promQL":[
+    "sum(irate(kafka_server_brokertopicmetrics_totalfetchrequests_total{ContextTags,topic=\"\"}[1m]))",
+    "sum(irate(kafka_server_brokertopicmetrics_failedfetchrequests_total{ContextTags,topic=\"\"}[1m]))"
+  ]},
+  {"graphName":"Network Processor Avg Idle Percent", "promQL":["kafka_network_socketserver_networkprocessoravgidle_percent{ContextTags}*100"]},
+  {"graphName":"Request Handler Avg Idle Percent", "promQL":["kafka_server_kafkarequesthandlerpool_requesthandleravgidle_percent{ContextTags}*100"]}
+]

--- a/enterprise-suite/es-grafana/kafka-exporter.json
+++ b/enterprise-suite/es-grafana/kafka-exporter.json
@@ -1,7 +1,7 @@
 [
   {"graphName":"Brokers Online", "promQL":["count(kafka_server_replicamanager_leadercount{ContextTags})"]},
   {"graphName":"Active Controllers", "promQL":["sum(kafka_controller_kafkacontroller_activecontrollercount{ContextTags})"]},
-  {"graphName":"Unclean Leader Election Rate", "promQL":["sum(rate(kafka_controller_controllerstats_uncleanleaderelections_total{ContextTags}[5m]))"]},
+  {"graphName":"Unclean Leader Election Rate", "promQL":["sum(irate(kafka_controller_controllerstats_uncleanleaderelections_total{ContextTags}[5m]))"]},
   {"graphName":"Online Partitions", "promQL":["sum(kafka_server_replicamanager_partitioncount{ContextTags})"]},
   {"graphName":"Under Replicated Partitions", "promQL":["sum(kafka_server_replicamanager_underreplicatedpartitions{ContextTags})"]},
   {"graphName":"Offline Partitions Count", "promQL":["sum(kafka_controller_kafkacontroller_offlinepartitionscount{ContextTags})"]},

--- a/enterprise-suite/es-grafana/zookeeper-exporter.json
+++ b/enterprise-suite/es-grafana/zookeeper-exporter.json
@@ -1,7 +1,13 @@
 [
-  {"graphName":"Average Latency", "promQL":["avg(zk_avg_latency{ContextTags})"]},
+  {"graphName":"Quorum Size", "promQL":["avg(zookeeper_quorumsize{ContextTags})"]},
+  {"graphName":"Alive Connections", "promQL":["sum(zookeeper_numaliveconnections{ContextTags})"]},
+  {"graphName":"Number of ZNodes", "promQL":["avg(zookeeper_inmemorydatatree_nodecount{ContextTags})"]},
+  {"graphName":"Number of Watchers", "promQL":["sum(zookeeper_inmemorydatatree_watchcount{ContextTags})"]},
+  {"graphName":"Outstanding Requests", "promQL":["zookeeper_outstandingrequests{ContextTags}"]},
+  {"graphName":"Request Latency - Minimum", "promQL":["zookeeper_minrequestlatency{ContextTags}"]},
+  {"graphName":"Request Latency - Average", "promQL":["zookeeper_avgrequestlatency{ContextTags}"]},
+  {"graphName":"Request Latency - Maximum", "promQL":["zookeeper_maxrequestlatency{ContextTags}"]},
   {"graphName":"Synced Followers", "promQL":["zk_synced_followers{ContextTags}"]},
   {"graphName":"Open File Descriptors", "promQL":["zk_open_file_descriptor_count{ContextTags}"]},
-  {"graphName":"Pending Syncs", "promQL":["zk_pending_syncs{ContextTags}"]},
-  {"graphName":"Connections", "promQL":["zk_num_alive_connections{ContextTags}"]}
+  {"graphName":"Pending Syncs", "promQL":["zk_pending_syncs{ContextTags}"]}
 ]

--- a/enterprise-suite/es-grafana/zookeeper-exporter.json
+++ b/enterprise-suite/es-grafana/zookeeper-exporter.json
@@ -1,5 +1,5 @@
 [
-  {"graphName":"Quorum Size", "promQL":["avg(zookeeper_quorumsize{ContextTags})"]},
+  {"graphName":"Quorum Size", "promQL":["max(zookeeper_quorumsize{ContextTags})"]},
   {"graphName":"Alive Connections", "promQL":["sum(zookeeper_numaliveconnections{ContextTags})"]},
   {"graphName":"Number of ZNodes", "promQL":["avg(zookeeper_inmemorydatatree_nodecount{ContextTags})"]},
   {"graphName":"Number of Watchers", "promQL":["sum(zookeeper_inmemorydatatree_watchcount{ContextTags})"]},


### PR DESCRIPTION
Updated set of exported grafana charts for Kafka and ZK workloads.  Fixes issue: https://github.com/lightbend/es-backend/issues/305

Some things to note:

* Generic JVM metrics exported by prometheus JMX exporter are incompatible with the metrics monitored in the "JVM Metrics" sections of generated grafana dashboards.  @dbrinegar has an issue for this: https://github.com/lightbend/es-backend/issues/335
* ZooKeeper workloads are not being identified.  Issue: https://github.com/lightbend/console-home/issues/357
* Some ZooKeeper metrics like Open File Descriptors and Synced Followers aren't exposed as JMX metrics and will require the ZooKeeper exporter running to retrieve.
* Monitoring Disk and Memory is critical for Kafka.  Issue: https://github.com/lightbend/es-backend/issues/310