### PR TITLE
Several improvements to the install script

### DIFF
--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -92,17 +92,15 @@ install-helm:  ## Install required helm components into cluster
 	-kubectl create clusterrolebinding $(TILLER_NAMESPACE):tiller --clusterrole=cluster-admin --serviceaccount=$(TILLER_NAMESPACE):tiller
 	-helm init --wait --service-account tiller --tiller-namespace=$(TILLER_NAMESPACE)
 
-delete-local:  ## Delete chart from cluster with helm
-	-helm delete --purge $(RELEASE_NAME)
-
 # called from shell script for travis job:
-install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm delete-local  ## Install local tarball
+install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm  ## Install local tarball
 	# We set a podUID here for test purposes to ensure everything works as non-root.
-	-ES_LOCAL_CHART=$(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz \
+	-ES_LOCAL_CHART=$(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz ES_FORCE_INSTALL=true \
 		$(CHART_DIR)/install-es.sh --wait --set minikube=$(MINIKUBE),podUID=10001
 
-install-dev: install-helm delete-local  ## Install content of enterprise-suite/ folder
-	ES_LOCAL_CHART=$(CHART_DIR) $(CHART_DIR)/install-es.sh --wait --set minikube=$(MINIKUBE)
+install-dev: install-helm ## Install content of enterprise-suite/ folder
+	ES_LOCAL_CHART=$(CHART_DIR) ES_FORCE_INSTALL=true \
+        	$(CHART_DIR)/install-es.sh --wait --set minikube=$(MINIKUBE)
 
 help:  ## Print help for targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(lastword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/enterprise-suite/install-es.sh
+++ b/enterprise-suite/install-es.sh
@@ -25,7 +25,8 @@ function usage() {
     docvar ES_CHART "Chart name to install from the repository"
     docvar ES_NAMESPACE "Namespace to install ES-Console into"
     docvar ES_LOCAL_CHART "Set to location of local chart tarball"
-    docvar ES_UPGRADE "Set to true to perform a helm upgrade instead of an install"
+    docvar ES_HELM_NAME "Helm release name"
+    docvar ES_FORCE_INSTALL "Set to true to delete an existing install first, instead of upgrading"
     docvar DRY_RUN "Set to true to dry run the install script"
     exit 1
 }
@@ -61,6 +62,22 @@ function import_credentials() {
     fi
 }
 
+function debug() {
+    echo "$@"
+    if [ "false" == "$DRY_RUN" ]; then
+        eval "$@"
+    fi
+}
+
+function chart_installed() {
+    local name=$1
+    if [ -n "${ES_STUB_CHART_STATUS:-}" ]; then
+        return $ES_STUB_CHART_STATUS
+    else
+        debug "helm status $name > /dev/null 2>&1"
+    fi
+}
+
 # User overridable variables.
 LIGHTBEND_COMMERCIAL_USERNAME=${LIGHTBEND_COMMERCIAL_USERNAME:-}
 LIGHTBEND_COMMERCIAL_PASSWORD=${LIGHTBEND_COMMERCIAL_PASSWORD:-}
@@ -69,7 +86,8 @@ ES_REPO=${ES_REPO:-https://lightbend.github.io/helm-charts}
 ES_CHART=${ES_CHART:-enterprise-suite}
 ES_NAMESPACE=${ES_NAMESPACE:-lightbend}
 ES_LOCAL_CHART=${ES_LOCAL_CHART:-}
-ES_UPGRADE=${ES_UPGRADE:-false}
+ES_HELM_NAME=${ES_HELM_NAME:-enterprise-suite}
+ES_FORCE_INSTALL=${ES_FORCE_INSTALL:-false}
 DRY_RUN=${DRY_RUN:-false}
 
 # Help
@@ -77,10 +95,10 @@ if [ "${1-:}" == "-h" ]; then
     usage
 fi
 
-# Setup dry-run
-debug=
-if [ "$DRY_RUN" == "true" ]; then
-    debug=echo
+# Check if version has been set
+if [[ ! "$*" =~ "version" ]]; then
+    echo "warning: --version has not been set, helm will use the latest available version. \
+It is recommended to use an explicit version."
 fi
 
 # Get credentials
@@ -91,17 +109,30 @@ if [ -n "$ES_LOCAL_CHART" ]; then
     # Install from a local chart tarball if ES_LOCAL_CHART is set.
     chart_ref=$ES_LOCAL_CHART
 else
-    $debug helm repo add es-repo "$ES_REPO"
-    $debug helm repo update
+    debug helm repo add es-repo "$ES_REPO"
+    debug helm repo update
     chart_ref=es-repo/$ES_CHART
 fi
 
-if [ "true" == "$ES_UPGRADE" ]; then
-    $debug helm upgrade es "$chart_ref" \
+# Determine if we should upgrade or install
+should_upgrade=
+if chart_installed "$ES_HELM_NAME"; then
+    if [ "true" == "$ES_FORCE_INSTALL" ]; then
+        debug helm delete --purge "$ES_HELM_NAME"
+        should_upgrade=false
+    else
+        should_upgrade=true
+    fi
+else
+    should_upgrade=false
+fi
+
+if [ "true" == "$should_upgrade" ]; then
+    debug helm upgrade "$ES_HELM_NAME" "$chart_ref" \
         --set imageCredentials.username="$repo_username",imageCredentials.password="$repo_password" \
         $@
 else
-    $debug helm install "$chart_ref" --name=es --namespace="$ES_NAMESPACE" \
+    debug helm install "$chart_ref" --name="$ES_HELM_NAME" --namespace="$ES_NAMESPACE" \
         --set imageCredentials.username="$repo_username",imageCredentials.password="$repo_password" \
         $@
 fi

--- a/enterprise-suite/templates/NOTES.txt
+++ b/enterprise-suite/templates/NOTES.txt
@@ -7,5 +7,5 @@ To learn more about the release, try:
   $ helm status {{ .Release.Name }}
   $ helm get {{ .Release.Name }}
 
-If you want to run {{ .Release.Name }} with exposed services, appropriate only for a minikube environment, reinstall the chart, specifying minikube=true.  e.g.
-  $ helm install lightbend-helm-charts/{{ .Chart.Name }} --name=es --namespace=lightbend --debug --wait --set minikube=true
+See https://developer.lightbend.com/docs/enterprisesuiteconsole/beta/installation/index.html for
+install options.


### PR DESCRIPTION
- Use a more descriptive helm release name with less chance of
conflicts.
- Detect if chart is already installed, and perform an upgrade instead.
- Print out the helm commands that get run.
- Warn if version is unspecified.
- Add ES_FORCE_INSTALL which will delete the existing chart first
instead of upgrading.

I also removed part of NOTES.txt which is out of date, and replaced
it with a link to the documentation.