### PR TITLE
akka_http monitor fixes

### DIFF
--- a/enterprise-suite/es-grafana/akka-http-exporter.json
+++ b/enterprise-suite/es-grafana/akka-http-exporter.json
@@ -2,7 +2,7 @@
   {"graphName":"Responses Per Second", "promQL":["sum by (request_path)(irate(akka_http_request_path_endpoint_responses{ContextTags}[1m]))"]},
   {"graphName":"Response Time", "promQL":["max by (request_path)(akka_http_request_path_endpoint_response_time_ns{ContextTags,quantile=\"0.99\"})"]},
   {"graphName":"Connections Per Second", "promQL":["sum by (http_server)(irate(akka_http_http_server_connections{ContextTags}[1m]))"]},
-  {"graphName":"Response Time 2XX", "promQL":["max by (http_server)(akka_http_http_server_response_time_2xx_ns{ContextTags, quantile=\"0.99\"})"]},
-  {"graphName":"Response Time 4XX", "promQL":["max by (http_server)(akka_http_http_server_response_time_4xx_ns{ContextTags, quantile=\"0.99\"})"]},
-  {"graphName":"Response Time 5XX", "promQL":["max by (http_server)(akka_http_http_server_response_time_5xx_ns{ContextTags, quantile=\"0.99\"})"]}
+  {"graphName":"Response Time 2XX 99% (ms)", "promQL":["max by (http_server)(akka_http_http_server_response_time_2xx_ns{ContextTags, quantile=\"0.99\"}) / 1000000"]},
+  {"graphName":"Response Time 4XX 99% (ms)", "promQL":["max by (http_server)(akka_http_http_server_response_time_4xx_ns{ContextTags, quantile=\"0.99\"}) / 1000000"]},
+  {"graphName":"Response Time 5XX 99% (ms)", "promQL":["max by (http_server)(akka_http_http_server_response_time_5xx_ns{ContextTags, quantile=\"0.99\"}) / 1000000"]}
 ]

--- a/enterprise-suite/es-grafana/play-exporter.json
+++ b/enterprise-suite/es-grafana/play-exporter.json
@@ -1,10 +1,4 @@
 [
-  {"graphName":"Responses Per Second", "promQL":["sum by (request_path)(irate(akka_http_request_path_endpoint_responses{ContextTags}[1m]))"]},
-  {"graphName":"Response Time", "promQL":["max by (request_path)(akka_http_request_path_endpoint_response_time_ns{ContextTags,quantile=\"0.99\"})"]},
-  {"graphName":"Connections Per Second", "promQL":["sum by (http_server)(irate(akka_http_http_server_connections{ContextTags}[1m]))"]},
-  {"graphName":"Response Time 2XX", "promQL":["max by (http_server)(akka_http_http_server_response_time_2xx_ns{ContextTags, quantile=\"0.99\"})"]},
-  {"graphName":"Response Time 4XX", "promQL":["max by (http_server)(akka_http_http_server_response_time_4xx_ns{ContextTags, quantile=\"0.99\"})"]},
-  {"graphName":"Response Time 5XX", "promQL":["max by (http_server)(akka_http_http_server_response_time_5xx_ns{ContextTags, quantile=\"0.99\"})"]},
   {"graphName":"Play Client Requests Per Second", "promQL":["sum by (http_client)(irate(play_http_client_play_client_requests{ContextTags}[1m]))"]},
   {"graphName":"Play Client Response Time", "promQL":["max by (http_client)(play_http_client_play_client_service_response_time_ns{ContextTags, quantile=\"0.99\"})"]}
 ]

--- a/enterprise-suite/es-monitor-api/bootstrap-monitors.json
+++ b/enterprise-suite/es-monitor-api/bootstrap-monitors.json
@@ -608,11 +608,11 @@
       "model": "threshold",
       "parameters": {
         "name": "akka_http_server_5xx",
-        "metric": "akka_http_http_server_responses_5xx",
+        "metric": "akka_http_http_server_responses_5xx_rate",
         "comparator": ">",
         "threshold": "0",
         "window": "5m",
-        "confidence": "1",
+        "confidence": "0.25",
         "severity": "warning",
         "summary": "HTTP 5xx errors",
         "description": "HTTP server at {{labels.instance}} has 5xx errors",

--- a/enterprise-suite/es-monitor-api/bootstrap-monitors.json
+++ b/enterprise-suite/es-monitor-api/bootstrap-monitors.json
@@ -612,7 +612,7 @@
         "comparator": ">",
         "threshold": "0",
         "window": "5m",
-        "confidence": "0.25",
+        "confidence": "1.0",
         "severity": "warning",
         "summary": "HTTP 5xx errors",
         "description": "HTTP server at {{labels.instance}} has 5xx errors",

--- a/enterprise-suite/es-monitor-api/static-rules.yml
+++ b/enterprise-suite/es-monitor-api/static-rules.yml
@@ -73,3 +73,5 @@
 - record: memcached_evictions_rate
   expr: rate(memcached_items_evicted_total[5m])
 
+- record: akka_http_http_server_responses_5xx_rate
+  expr: rate(akka_http_http_server_responses_5xx)

--- a/enterprise-suite/es-monitor-api/static-rules.yml
+++ b/enterprise-suite/es-monitor-api/static-rules.yml
@@ -74,4 +74,4 @@
   expr: rate(memcached_items_evicted_total[5m])
 
 - record: akka_http_http_server_responses_5xx_rate
-  expr: rate(akka_http_http_server_responses_5xx)
+  expr: rate(akka_http_http_server_responses_5xx[5m])


### PR DESCRIPTION
- Use a rate for 5xx monitor so we don't go permanently unhealthy.
- Remove duplicate graphs in the play-exporter.json
- Specify percentile and use ms for the akka_http response times.

For https://github.com/lightbend/es-backend/issues/345