### PR TITLE
Add extra busy wait timeout in frontend e2e test

### DIFF
--- a/enterprise-suite/tests/e2e/cypress/support/cluster-details.ts
+++ b/enterprise-suite/tests/e2e/cypress/support/cluster-details.ts
@@ -1,7 +1,7 @@
 export class ClusterDetails {
     static infraContains(key: string, value: string) {
         cy.get('rc-panel[title="Infrastructure"]')
-            .contains('.label-key', key)
+            .contains('.label-key', key, {timeout: 10000})
             .parent()
             .contains('.label-value', value, {timeout: 10000});
     }

--- a/enterprise-suite/tests/e2e/cypress/support/navigation.ts
+++ b/enterprise-suite/tests/e2e/cypress/support/navigation.ts
@@ -5,7 +5,7 @@ export class Navigation {
     }
 
     static clickWorkload(workloadId: string) {
-        cy.get('rc-workload-table').contains(workloadId).click();
+        cy.get(`rc-workload-table .workload-row[workloadname="${workloadId}"]`, {timeout: 10000}).click();
         cy.url().should('include', `/workloads/${workloadId}`);
     }
 
@@ -15,7 +15,7 @@ export class Navigation {
     }
 
     static clickMonitor(monId: string) {
-        cy.get('.monitor-list').contains(monId).click();
+        cy.get(`.monitor-list .monitor-name[title="${monId}"]`, {timeout: 12000}).click();
     }
 
     static goMonitorPage(workloadId: string, monitorId: string) {


### PR DESCRIPTION
@marcoderama found some e2e tests are flaky due to busy wait timeout is not long enough.  Add extra timeout for it. (note: the default timeout is 4000)