### PR TITLE
Proxy alertmanager, add example config, make it customizable

### DIFF
--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -105,12 +105,12 @@ install-helm:  ## Install required helm components into cluster
 	-kubectl create namespace $(TILLER_NAMESPACE)
 	-kubectl create serviceaccount --namespace $(TILLER_NAMESPACE) tiller
 	-kubectl create clusterrolebinding $(TILLER_NAMESPACE):tiller --clusterrole=cluster-admin --serviceaccount=$(TILLER_NAMESPACE):tiller
-	-helm init --wait --service-account tiller --tiller-namespace=$(TILLER_NAMESPACE)
+	-helm init --wait --service-account tiller --upgrade --tiller-namespace=$(TILLER_NAMESPACE)
 
 # called from shell script for travis job:
 install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm  ## Install local tarball
 	# We set a podUID here for test purposes to ensure everything works as non-root.
-	-ES_LOCAL_CHART=$(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz ES_FORCE_INSTALL=true \
+	-ES_LOCAL_CHART=$(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz \
 	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE),podUID=10001
 
 # helm settings for installing from local files
@@ -118,7 +118,7 @@ install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm  ## Install l
 DEV_HELM_VALUES_FLAG = $(if $(DEV_HELM_VALUES_FILE), --values $(DEV_HELM_VALUES_FILE))
 
 install-dev: install-helm ## Install content of enterprise-suite/ folder
-	ES_LOCAL_CHART=$(CHART_DIR) ES_FORCE_INSTALL=true \
+	ES_LOCAL_CHART=$(CHART_DIR) \
 	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE) $(DEV_HELM_VALUES_FLAG)
 
 help:  ## Print help for targets

--- a/enterprise-suite/alertmanager/alertmanager.yml
+++ b/enterprise-suite/alertmanager/alertmanager.yml
@@ -1,0 +1,55 @@
+# Example Lightbend Console Alertmanager config.
+
+global:
+
+# Routing rules.
+route:
+  receiver: slack
+  # Resend unresolved alerts at this interval.
+  repeat_interval: 4h
+  # Wait for any other alerts in the same group before sending.
+  group_wait: 30s
+  # Wait before sending a new alert for a group.
+  group_interval: 5m
+  # Group alerts by namespace and workload.
+  group_by: [namespace, es_workload]
+  routes:
+  - match:
+      severity: warning
+    receiver: slack
+  - match:
+      severity: critical
+    receiver: slack
+    continue: true
+  - match:
+      severity: critical
+    receiver: pagerduty
+
+# Don't alert on warnings if the same alert is already critical.
+inhibit_rules:
+- source_match:
+    severity: critical
+  target_match:
+    severity: warning
+  equal: [alertname]
+
+templates:
+# Slack notification templates.
+- '/etc/config/slack.tmpl'
+
+# Receivers.
+receivers:
+- name: slack
+  slack_configs:
+  # Use Slack integrations to find the webhook.
+  - api_url: https://slack.localhost/services/somewhere
+    channel: '#my-alerts'
+    title: '{{ template "title.slack" . }}'
+    text: '{{ template "text.slack" . }}'
+    send_resolved: true
+
+- name: pagerduty
+  pagerduty_configs:
+  - url: https://pagerduty.localhost/api
+    routing_key: my_secret_routing_key
+    service_key: my_secret_service_key

--- a/enterprise-suite/alertmanager/slack.tmpl
+++ b/enterprise-suite/alertmanager/slack.tmpl
@@ -1,0 +1,4 @@
+{{ define "title.slack" }}{{ .GroupLabels.namespace}}/{{ .GroupLabels.es_workload }} [{{ .Status | toUpper }}][{{ .CommonLabels.severity | toUpper }}]{{ end }}
+{{ define "text.slack" }}{{ range $index, $element := .Alerts }}_{{ .Annotations.summary }}_
+    {{ .Annotations.description }}
+{{ end }}{{- end -}}

--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -1,35 +1,4 @@
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: prometheus
-    component: alertmanager
-  name: prometheus-alertmanager
-data:
-  alertmanager.yml: |-
-    global:
-      # ref:  https://typesafe.slack.com/apps/new/incoming-webhooks
-
-    receivers:
-      - name: default
-      #  slack_configs:
-      #  - channel: '#es-alert'
-      #    send_resolved: true
-
-    route:
-      receiver: default
-      group_by: [es_workload]
-
-    # don't alert on warnings if the same alert is already critical
-    inhibit_rules:
-    - source_match:
-        severity: critical
-      target_match:
-        severity: warning
-      equal: [alertname]
-
----
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -103,7 +72,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: prometheus-alertmanager
+            name: {{ .Values.alertManagerConfigMap }}
         - name: data-volume
           emptydir: {}
 
@@ -124,3 +93,28 @@ spec:
     component: alertmanager
   type: NodePort
 {{ end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager
+spec:
+  ports:
+  - port: 9093
+    targetPort: 9093
+  selector:
+    app: prometheus
+    component: alertmanager
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: prometheus
+    component: alertmanager
+  name: alertmanager-default
+data:
+{{ (.Files.Glob "alertmanager/*").AsConfig | indent 2}}

--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -29,12 +29,13 @@ spec:
         ports:
         - containerPort: 8080
         volumeMounts:
-          - name: config-volume
-            mountPath: /etc/nginx/conf.d
-      volumes:
         - name: config-volume
-          configMap:
-            name: es-console
+          mountPath: /etc/nginx/conf.d
+
+      volumes:
+      - name: config-volume
+        configMap:
+          name: es-console
 
 {{ if .Values.minikube }}
 ---
@@ -93,5 +94,9 @@ data:
 
       location /service/grafana/ {
         proxy_pass http://grafana-server:3000/;
+      }
+
+      location /service/alertmanager/ {
+        proxy_pass http://alertmanager/;
       }
     }

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -35,6 +35,8 @@ imageCredentials:
   registry: lightbend-docker-commercial-registry.bintray.io
   username: setme
   password: setme
+# Alertmanager ConfigMap. Set to the name of a ConfigMap, with a file `alertmanager.yml`.
+alertManagerConfigMap: alertmanager-default
 
 #################################################
 # ResourceRequests


### PR DESCRIPTION
This adds additional support for configuring alertmanager:
- Helm parameter for selecting a user provided ConfigMap for the alertmanager config
- Greatly expanded the example to help users get started quicker
- Proxy alertmanager via the console nginx
