### PR TITLE
Update make-release.sh to work with helm-charts changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,26 @@ Then run the release script on a clean master checkout:
     scripts/make-release.sh enterprise-suite
     git push --follow-tags
     
-This will increment the chart version, package it, and make a
+The `make-release.sh` script will create the chart tarball, push it to the `docs`
+directory, rebuild the `index.yaml` file, and then make a
 commit. Finally, `git push --tags` will publish the release and git tag.
 
-Optionally you can specify the version to use:
+By default, the build uses the version specified in the `Chart.yaml`
+file.  The version number will be auto-incremented for the next build.
+Optionally, you can specify the version to use:
 
     scripts/make-release.sh enterprise-suite 1.0.0
+
+This is useful if you want to increment the major or minor version
+number.  In the example above, the build would use v1.0.0 and `Chart.yaml` would then
+be setup for the next build with version 1.0.1.
 
 ### Enterprise Suite Console
 
 See [ES Build and Release](https://docs.google.com/document/d/14L3Zdwc-MkCDR1-7fWQYQT3k53vLc4cehAKEuOnwhxs/edit)
-for details on the overall release process.
+for details on the overall release process.  (Note that for the
+`enterprise-suite` project, we automatically build and publish the
+`enterprise-suite-latest` project at the same time.)
 
 ## Maintenance
 

--- a/common.mk
+++ b/common.mk
@@ -6,13 +6,13 @@
 
 HELM_CHARTS_DIR = ..
 
-lint: init
-	helm lint .
-
 # Package up the chart files and move the tarball to the helm-charts repository.
 # Include a .helmignore file in your directory to specify files to omit from the package.
 package: init
 	helm package -d $(HELM_CHARTS_DIR)/docs .
+
+lint: init
+	helm lint .
 
 # This satifies the need for a test target but does nothing.
 test:

--- a/enterprise-suite/Chart.yaml
+++ b/enterprise-suite/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: Lightbend Enterprise Suite
 name: enterprise-suite
 icon: https://repo.lightbend.com/helm-charts/lightbend.svg
-version: 0.9.1
+version: 0.9.2

--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -29,7 +29,7 @@ all: lint build  ## lint then build chart
 build: init package $(HELM_CHARTS_DIR)/docs/$(RELEASE_NAME)/$(ALL_YAML)  ## Build chart package (and all.yaml)
 
 # This target required by top-level helm-charts Makefile.  Will create chart tarball in docs directory
-package: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz
+package: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz  ## Build chart tarball
 
 shell-tests:
 	$(CHART_DIR)/tests/lib/bats/bats $(CHART_DIR)/tests
@@ -48,7 +48,7 @@ frontend-tests:
 #
 # The conditional bit is so we can control which set of tests are run given we're only
 # allowed a single 'test' target.
-test:
+test:  ## Run tests.  backend-tests by default.  Set env var ES_TEST=frontend to run front end tests.
 ifneq ($(ES_TEST),frontend)
 	$(MAKE) backend-tests
 else
@@ -107,22 +107,22 @@ install-helm:  ## Install required helm components into cluster
 	-kubectl create clusterrolebinding $(TILLER_NAMESPACE):tiller --clusterrole=cluster-admin --serviceaccount=$(TILLER_NAMESPACE):tiller
 	-helm init --wait --service-account tiller --upgrade --tiller-namespace=$(TILLER_NAMESPACE)
 
+# helm settings for installing locally
+# If set, HELM_VALUES_FILE will be added as '--values' value to install command, overriding default values.
+HELM_VALUES_FLAG=$(if $(HELM_VALUES_FILE),--values $(HELM_VALUES_FILE))
+
 # called from shell script for travis job:
 install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm  ## Install local tarball
 	# We set a podUID here for test purposes to ensure everything works as non-root.
 	-ES_LOCAL_CHART=$(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz \
-	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE),podUID=10001
-
-# helm settings for installing from local files
-# If set, DEV_HELM_VALUES_FILE will be added as '--values' value to install command, overriding default values.
-DEV_HELM_VALUES_FLAG = $(if $(DEV_HELM_VALUES_FILE), --values $(DEV_HELM_VALUES_FILE))
+	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE),podUID=10001 $(HELM_VALUES_FLAG)
 
 install-dev: install-helm ## Install content of enterprise-suite/ folder
 	ES_LOCAL_CHART=$(CHART_DIR) \
-	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE) $(DEV_HELM_VALUES_FLAG)
+	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE) $(HELM_VALUES_FLAG)
 
 help:  ## Print help for targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(lastword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: all build package shell-tests minikube-tests test init lint lint-helm lint-json lint-promql clean \
-		install-helm delete-local install-local help
+		install-helm install-local install-dev help

--- a/reactive-sandbox/Chart.yaml
+++ b/reactive-sandbox/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A collection of external services required to run Lightbend Reactive Platform applications
 name: reactive-sandbox
-version: 0.2.0
+version: 0.2.1


### PR DESCRIPTION
- Uses version in Chart.yaml and post-increments.
- Version numbers in `enterprise-suite` and `reactive-sandbox` incremented so the next build will have the right version number.  (No change for `sample-project` because it hasn't been released yet.)