### PR TITLE
small fixes to nginx

### DIFF
--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -125,19 +125,6 @@ data:
         proxy_redirect '/' ' $1/';
       }
 
-      location ~ (.*/service/grafana)(/.*) {
-        proxy_pass http://$grafana:3000$2$is_args$args;
-        sub_filter_types *;
-        sub_filter '/service/grafana' '$1';
-        proxy_cookie_path '/service/grafana' '$1';
-        proxy_redirect '/' ' $1/';
-      }
-
-      location ~ (.*/service/alertmanager)(/.*) {
-        proxy_pass http://$alertmanager:9093$2$is_args$args;
-        proxy_redirect '/' ' $1/';
-      }
-
       # our injected plugin should never cache...
       location ~ (.*/service/grafana)(/dashboard/script/exporter-async.js) {
         proxy_pass http://$grafana:3000$2$is_args$args;
@@ -153,9 +140,22 @@ data:
         etag off;
       }
 
+      location ~ (.*/service/grafana)(/.*) {
+        proxy_pass http://$grafana:3000$2$is_args$args;
+        sub_filter_types *;
+        sub_filter '/service/grafana' '$1';
+        proxy_cookie_path '/service/grafana' '$1';
+        proxy_redirect '/' ' $1/';
+      }
+
+      location ~ (.*/service/alertmanager)(/.*) {
+        proxy_pass http://$alertmanager:9093$2$is_args$args;
+        proxy_redirect '/' ' $1/';
+      }
+
       # redirect /service/prometheus -> /service/prometheus/
 
-      location ~ (.*/service/(prometheus|grafana))$ {
+      location ~ (.*/service/(prometheus|grafana|alertmanager))$ {
         return 301 ' $1/';
       }
 

--- a/enterprise-suite/tests/smoke_nginx
+++ b/enterprise-suite/tests/smoke_nginx
@@ -4,6 +4,10 @@ source smokecommon
 
 CONSOLE=$( busy_wait nodeport expose-es-console)
 
+#
+# arbitrary base path
+#
+
 BASEPATH="${CONSOLE}/fee/fie/fou/fum"
 
 test_es_console_responding "$BASEPATH/"
@@ -11,3 +15,30 @@ test_grafana_responding "$BASEPATH/service/grafana/"
 test_prom_responding "$BASEPATH/service/prometheus/"
 test_es_monitor_API_responding "$BASEPATH/service/es-monitor-api/"
 test_alertmanager_responding "$BASEPATH/service/alertmanager/"
+
+#
+# redirects
+#
+
+test_redirect() {
+    redir=$( curl_headers "$1" | awk '$1=="Location:"{print $2}' )
+    [[ $redir == "$2" ]]
+    T $? "$1" redirects to "$2"
+}
+test_redirect "${CONSOLE}/service/prometheus"   "/service/prometheus/"
+test_redirect "${CONSOLE}/service/grafana"      "/service/grafana/"
+test_redirect "${CONSOLE}/service/alertmanager" "/service/alertmanager/"
+
+#
+# cache busting
+#
+
+test_no_cache() {
+    cache_control=$( curl_headers "$1" | awk -F ': ' '$1=="Cache-Control"{print $2}' )
+    [[ $cache_control == "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" ]]
+    T $? "$1" has cache control
+}
+
+test_no_cache "${CONSOLE}/cluster"
+test_no_cache "${CONSOLE}/workloads/prometheus-server"
+test_no_cache "${CONSOLE}/service/grafana/dashboard/script/exporter-async.js?service-type=cluster"

--- a/enterprise-suite/tests/smokecommon
+++ b/enterprise-suite/tests/smokecommon
@@ -82,6 +82,11 @@ curl_query() {
   curl -fsG "$@" "$FETCH_BASE/$FETCH_URI"
 }
 
+curl_headers() {
+    # NB: curl -I prints \n\r line endings
+    curl -sI "$1" | tr -d '\r'
+}
+
 
 # ES console access test
 # test_es_console_responding <url> [<curl-opt>...]


### PR DESCRIPTION
some little things I've noticed over past few days

1. alertmanager should redirect to alertmanager/
2. order of locations was preventing grafana plugin location rules from
applying the no-cache settings. locations have to go specific to general
3. smoke tests for redirs and cache busting