### PR TITLE
Use build-helm-charts for generating the index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ jobs:
     # Decrypt credentials for GCS system account helmchart@es-repo.iam.gserviceaccount.com
     - openssl aes-256-cbc -K $encrypted_f01ffbb90c44_key -iv $encrypted_f01ffbb90c44_iv -in resources/es-repo-7c1fefe17951.json.enc -out resources/es-repo-7c1fefe17951.json -d
     - scripts/deploy-to-gcs.sh
+    - scripts/trigger-build-helm-charts.sh
 
 branches:
   only:

--- a/scripts/build-helm-charts.sh
+++ b/scripts/build-helm-charts.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+body='{
+"request": {
+"branch":"master"
+}}'
+
+curl -s -X POST \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
+   -H "Travis-API-Version: 3" \
+   -H "Authorization: token $TRAVIS_CI_TOKEN" \
+   -d "$body" \
+   https://api.travis-ci.com/repo/travis-ci%2Ftravis-core/requests

--- a/scripts/deploy-to-gcs.sh
+++ b/scripts/deploy-to-gcs.sh
@@ -24,7 +24,7 @@ usage () {
 # GCS project
 GCS_PROJECT=es-repo
 # GCS bucket within project
-: "${GCS_BUCKET:=lightbend-helm-charts}"
+: "${GCS_BUCKET:=lightbend-console-charts}"
 
 # HELM_DIR is helm-charts directory.  Defaults to cwd but can be overridden.
 : "${HELM_DIR:=$(pwd)}"


### PR DESCRIPTION
1. Put our artifacts in the new bucket `lightbend-console-charts`
2. Trigger a build on https://travis-ci.com/lightbend/build-helm-charts
   to generate the index.yaml.

See https://github.com/lightbend/build-helm-charts for more details.