### PR TITLE
install-es.sh copes with lacking newline

### DIFF
--- a/enterprise-suite/scripts/install-es.sh
+++ b/enterprise-suite/scripts/install-es.sh
@@ -63,7 +63,8 @@ function import_credentials() {
         repo_username=$LIGHTBEND_COMMERCIAL_USERNAME
         repo_password=$LIGHTBEND_COMMERCIAL_PASSWORD
     elif [ -e "$LIGHTBEND_COMMERCIAL_CREDENTIALS" ]; then
-        while IFS='=' read -r key value; do
+        while IFS= read -r prop || [ -n "$prop" ]; do
+            read key value <<< $( echo $prop | awk 'BEGIN { FS = ":" } { print $1 " " $2 }' )
             local trimmed_key
             trimmed_key=$(echo -e "$key" | tr -d '[:space:]')
             local trimmed_value

--- a/enterprise-suite/scripts/install-es.sh
+++ b/enterprise-suite/scripts/install-es.sh
@@ -63,8 +63,7 @@ function import_credentials() {
         repo_username=$LIGHTBEND_COMMERCIAL_USERNAME
         repo_password=$LIGHTBEND_COMMERCIAL_PASSWORD
     elif [ -e "$LIGHTBEND_COMMERCIAL_CREDENTIALS" ]; then
-        while IFS= read -r prop || [ -n "$prop" ]; do
-            read key value <<< $( echo $prop | awk 'BEGIN { FS = ":" } { print $1 " " $2 }' )
+        while IFS='=' read -r key value || [ -n "$key" ]; do
             local trimmed_key
             trimmed_key=$(echo -e "$key" | tr -d '[:space:]')
             local trimmed_value

--- a/enterprise-suite/tests/install-es.bats
+++ b/enterprise-suite/tests/install-es.bats
@@ -24,6 +24,14 @@ function setup {
     assert_output --regexp '.*helm install.*--values [^ ]*creds\..*'
 }
 
+@test "loads commercial credentials from file with no trailing newline" {
+    unset LIGHTBEND_COMMERCIAL_USERNAME
+    unset LIGHTBEND_COMMERCIAL_PASSWORD
+    LIGHTBEND_COMMERCIAL_CREDENTIALS="$BATS_TEST_DIRNAME/testdata/test_credentials_nonl " \
+        run $install_es
+    assert_output --regexp '.*helm install.*--values [^ ]*creds\..*'
+}
+
 @test "loads commercial credentials from env vars" {
     run $install_es
     assert_output --regexp '.*helm install.*--values [^ ]*creds\..*'

--- a/enterprise-suite/tests/install-es.bats
+++ b/enterprise-suite/tests/install-es.bats
@@ -27,7 +27,7 @@ function setup {
 @test "loads commercial credentials from file with no trailing newline" {
     unset LIGHTBEND_COMMERCIAL_USERNAME
     unset LIGHTBEND_COMMERCIAL_PASSWORD
-    LIGHTBEND_COMMERCIAL_CREDENTIALS="$BATS_TEST_DIRNAME/testdata/test_credentials_nonl " \
+    LIGHTBEND_COMMERCIAL_CREDENTIALS="$BATS_TEST_DIRNAME/testdata/test_credentials_nonl" \
         run $install_es
     assert_output --regexp '.*helm install.*--values [^ ]*creds\..*'
 }

--- a/enterprise-suite/tests/testdata/test_credentials_nonl
+++ b/enterprise-suite/tests/testdata/test_credentials_nonl
@@ -1,0 +1,4 @@
+realm = Bintray
+host = dl.bintray.com
+user = testuser
+password = myreallysecurepassword


### PR DESCRIPTION
Boris couldn't get `install-es.sh` to work.  Turns out it was because his credentials file didn't have a trailing newline character.