### PR TITLE
Provide name to console server port

### DIFF
--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -68,7 +68,8 @@ metadata:
   name: console-server
 spec:
   ports:
-    - port: 80
+    - name: console-server-port
+      port: 80
       targetPort: 8080
   selector:
     run: es-console


### PR DESCRIPTION
/lightbend/es-backend/issues/269

I didn't capture it, but on openshift there was an error message, providing a name resolved it.