### PR TITLE
Added POD_IP env var to the alertmanager pod template

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -31,6 +31,10 @@ spec:
               cpu: {{ default .Values.defaultCPURequest .Values.alertManagerCPURequest }}
               memory: {{ default .Values.defaultMemoryRequest .Values.alertManagerMemoryRequest }}
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           args:
             - --config.file=/etc/config/alertmanager.yml
             - --storage.path=/data


### PR DESCRIPTION
this allows the pod ip to be used by the prometheus operator when setting the 'cluster.listen-address' setting, allowing cluster to form correctly when running on DC/OS