### PR TITLE
Set the IP address explicitly for the alertmanager

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -31,9 +31,14 @@ spec:
               cpu: {{ default .Values.defaultCPURequest .Values.alertManagerCPURequest }}
               memory: {{ default .Values.defaultMemoryRequest .Values.alertManagerMemoryRequest }}
           env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           args:
             - --config.file=/etc/config/alertmanager.yml
             - --storage.path=/data
+            - --cluster.listen-address=$(POD_IP):6783
 
           ports:
             - containerPort: 9093


### PR DESCRIPTION
sets an env var and then uses that to set --cluster.listen-address