### PR TITLE
Add useEmptyDirVolumes option

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.useEmptyDirVolumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -10,6 +11,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.alertmanagerVolumeSize }}
+{{ end }}
 
 ---
 apiVersion: apps/v1beta2
@@ -92,8 +94,12 @@ spec:
           configMap:
             name: {{ .Values.alertManagerConfigMap }}
         - name: data-volume
+          {{ if .Values.useEmptyDirVolumes }}
+          emptyDir: {}
+          {{ else }}
           persistentVolumeClaim:
             claimName: alertmanager-storage
+          {{ end }}
 
 {{ if .Values.minikube }}
 ---

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -80,6 +80,7 @@ spec:
   type: NodePort
 {{ end }}
 
+{{ if not .Values.useEmptyDirVolumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -92,6 +93,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.esGrafanaVolumeSize }}
+{{ end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -161,5 +163,9 @@ spec:
         configMap:
           name: grafana-datasource-cm
       - name: grafana-data
+        {{ if .Values.useEmptyDirVolumes }}
+        emptyDir: {}
+        {{ else }}
         persistentVolumeClaim:
           claimName: es-grafana-storage
+        {{ end }}

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -40,6 +40,7 @@ subjects:
   name: prometheus-server
   namespace: {{.Release.Namespace}}
 
+{{ if not .Values.useEmptyDirVolumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -66,6 +67,7 @@ spec:
     requests:
       storage: {{ .Values.prometheusVolumeSize }}
 
+{{ end }}
 ---
 apiVersion: apps/v1beta2
 kind: Deployment
@@ -196,11 +198,19 @@ spec:
           configMap:
             name: es-monitor-api
         - name: monitor-data-volume
+          {{ if .Values.useEmptyDirVolumes }}
+          emptyDir: {}
+          {{ else }}
           persistentVolumeClaim:
             claimName: es-monitor-storage
+          {{ end }}
         - name: prometheus-data-volume
+          {{ if .Values.useEmptyDirVolumes }}
+          emptyDir: {}
+          {{ else }}
           persistentVolumeClaim:
             claimName: prometheus-storage
+          {{ end }}
         - name: bare-prometheus
           configMap:
             name: bare-prometheus

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -51,6 +51,8 @@ prometheusMemoryRequest: 250Mi
 #################################################
 # Persistent Volumes
 #
+# Set to true to use emptyDir for all volumes, disabling persistent volumes.
+useEmptyDirVolumes: false
 # Default StorageClass to use for persistent volumes
 defaultStorageClass: standard
 # Prometheus volume size - used for storing metrics data.


### PR DESCRIPTION
For users that don't have easy access to PVs, they can use emptyDir to
get started quickly.