### PR TITLE
Fix HELM_VALUES_FILE definition in enterprise-suite-latest Makefile

### DIFF
--- a/enterprise-suite-latest/Makefile
+++ b/enterprise-suite-latest/Makefile
@@ -24,7 +24,7 @@ CHART_DIR = ../$(ES_CHART)
 COMPONENTS := $(wildcard ../$(ES_CHART)/*/.)
 SUBCOMPONENTS := $(wildcard ../$(ES_CHART)/*/*/.)
 # Override dev helm settings using values-latest.yaml file
-DEV_HELM_VALUES_FILE = values-latest.yaml
+HELM_VALUES_FILE = values-latest.yaml
 
 # Special rule to build 'latest' chart
 $(HELM_CHARTS_DIR)/docs/$(filter %-latest,$(CHART))-$(VERSION).tgz: $(COMPONENTS) $(SUBCOMPONENTS)


### PR DESCRIPTION
Allows one to properly use `make install-dev` in the enterprise-suite-latest directory.