### PR TITLE
Wait longer

### DIFF
--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -261,8 +261,8 @@ data:
   prometheus.yml: |-
     # this is a placeholder to keep prometheus running while it awaits the real config
     global:
-      scrape_interval:     10m
-      evaluation_interval: 10m
+      scrape_interval:     99m
+      evaluation_interval: 99m
     scrape_configs:
       - job_name: wait
         static_configs:

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -259,10 +259,10 @@ metadata:
   name: bare-prometheus
 data:
   prometheus.yml: |-
-    # this is a placeholder to keep prometheus running while it waits the real config
+    # this is a placeholder to keep prometheus running while it awaits the real config
     global:
-      scrape_interval:     1m
-      evaluation_interval: 1m
+      scrape_interval:     10m
+      evaluation_interval: 10m
     scrape_configs:
       - job_name: wait
         static_configs:


### PR DESCRIPTION
fixes lightbend/es-backend#361

We can also focus our prometheus health rules on our working job / namespace / etc but will do that separately and post refactoring API so don't have to do twice