### PR TITLE
Turn off video compression for better debug info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
     script:
     - scripts/setup-minikube-for-linux.sh
     - make test CHARTS=enterprise-suite ES_TEST=frontend
-    after_script:
+    after_failure:
     # Cypress videos.
     - artifacts upload $(find . -name '*.mp4')
 

--- a/enterprise-suite/tests/e2e/cypress.json
+++ b/enterprise-suite/tests/e2e/cypress.json
@@ -8,5 +8,6 @@
     "reporterOptions": {
       "mochaFile": "results/[hash].xml",
       "toConsole": true
-    }
+    },
+    "videoCompression": false
 }


### PR DESCRIPTION
There are several "flaky" tasks today. Even we record video, we still don't know what is going on due to some video compression issue in linux.  I disable the video compress and only upload video when error happens to avoid it takes too much space in s3

There is a [videoCompression](https://docs.cypress.io/guides/references/configuration.html#Videos) parameter for cypress. 

```The quality setting for the video compression, in Constant Rate Factor (CRF). The value can be false to disable compression or a value between 0 and 51, where a lower value results in better quality (at the expense of a higher file size). The default value is 32```


The video is much better after turning off video compression. 
Here is the link for compressed video 
https://s3.amazonaws.com/lb-helm-build-artifacts/index.html?prefix=artifacts/lightbend/helm-charts/572/572.3/enterprise-suite/tests/e2e/cypress/videos/
Here is the link for uncompressed video 
https://s3.amazonaws.com/lb-helm-build-artifacts/index.html?prefix=artifacts/lightbend/helm-charts/573/573.3/enterprise-suite/tests/e2e/cypress/videos/

Here is their video size compared side by side
<img width="1379" alt="screen shot 2018-10-11 at 7 03 04 pm" src="https://user-images.githubusercontent.com/11674700/46843608-9989ee80-cd88-11e8-951d-9b8975f817e5.png">

If the video is uncompressed, it is around 3 MB in total. Personally I think that it is small enough. But it shows much more info.  We can compare the "es-grafana.spec.ts" test in the video and find the difference.  

If there is any concern for file size, I can adjust videoCompression parameter