### PR TITLE
show monitor name instead of fubar annotations

### DIFF
--- a/enterprise-suite/alertmanager/slack.tmpl
+++ b/enterprise-suite/alertmanager/slack.tmpl
@@ -1,4 +1,3 @@
 {{ define "title.slack" }}{{ .GroupLabels.namespace}}/{{ .GroupLabels.es_workload }} [{{ .Status | toUpper }}][{{ .CommonLabels.severity | toUpper }}]{{ end }}
-{{ define "text.slack" }}{{ range $index, $element := .Alerts }}_{{ .Annotations.summary }}_
-    {{ .Annotations.description }}
+{{ define "text.slack" }}{{ range $index, $element := .Alerts }}_{{ .CommonLabels.name }}_
 {{ end }}{{- end -}}


### PR DESCRIPTION
since the UI doesn't let one see or edit the annotations