### PR TITLE
Enable emptyDir volumes by default

### DIFF
--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -116,11 +116,12 @@ install-helm:  ## Install required helm components into cluster
 # If set, HELM_VALUES_FILE will be added as '--values' value to install command, overriding default values.
 HELM_VALUES_FLAG=$(if $(HELM_VALUES_FILE),--values $(HELM_VALUES_FILE))
 
-# called from shell script for travis job:
+# Used for minikube tests.
 install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm  ## Install local tarball
 	# We set a podUID here for test purposes to ensure everything works as non-root.
+	# We disable emptyDirVolumes to ensure PVCs work as expected.
 	-ES_LOCAL_CHART=$(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz \
-	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE),podUID=10001 $(HELM_VALUES_FLAG)
+	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE),podUID=10001,useEmptyDirVolumes=false $(HELM_VALUES_FLAG)
 
 install-dev: install-helm ## Install content of enterprise-suite/ folder
 	ES_LOCAL_CHART=$(CHART_DIR) \

--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -119,9 +119,9 @@ HELM_VALUES_FLAG=$(if $(HELM_VALUES_FILE),--values $(HELM_VALUES_FILE))
 # Used for minikube tests.
 install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm  ## Install local tarball
 	# We set a podUID here for test purposes to ensure everything works as non-root.
-	# We disable emptyDirVolumes to ensure PVCs work as expected.
+	# We usePersistentVolumes to ensure PVCs work as expected.
 	-ES_LOCAL_CHART=$(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz \
-	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE),podUID=10001,useEmptyDirVolumes=false $(HELM_VALUES_FLAG)
+	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE),podUID=10001,usePersistentVolumes=true $(HELM_VALUES_FLAG)
 
 install-dev: install-helm ## Install content of enterprise-suite/ folder
 	ES_LOCAL_CHART=$(CHART_DIR) \

--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.useEmptyDirVolumes }}
+{{ if .Values.usePersistentVolumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -94,11 +94,11 @@ spec:
           configMap:
             name: {{ .Values.alertManagerConfigMap }}
         - name: data-volume
-          {{ if .Values.useEmptyDirVolumes }}
-          emptyDir: {}
-          {{ else }}
+          {{ if .Values.usePersistentVolumes }}
           persistentVolumeClaim:
             claimName: alertmanager-storage
+          {{ else }}
+          emptyDir: {}
           {{ end }}
 
 {{ if .Values.minikube }}

--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -1,4 +1,3 @@
-{{ if .Values.usePersistentVolumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -11,7 +10,6 @@ spec:
   resources:
     requests:
       storage: {{ .Values.alertmanagerVolumeSize }}
-{{ end }}
 
 ---
 apiVersion: {{ .Values.deploymentApiVersion }}
@@ -94,7 +92,7 @@ spec:
           configMap:
             name: {{ .Values.alertManagerConfigMap }}
         - name: data-volume
-          {{ if .Values.usePersistentVolumes }}
+          {{ if or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes) }}
           persistentVolumeClaim:
             claimName: alertmanager-storage
           {{ else }}

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -80,7 +80,7 @@ spec:
   type: NodePort
 {{ end }}
 
-{{ if not .Values.useEmptyDirVolumes }}
+{{ if .Values.usePersistentVolumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -163,9 +163,9 @@ spec:
         configMap:
           name: grafana-datasource-cm
       - name: grafana-data
-        {{ if .Values.useEmptyDirVolumes }}
-        emptyDir: {}
-        {{ else }}
+        {{ if .Values.usePersistentVolumes }}
         persistentVolumeClaim:
           claimName: es-grafana-storage
+        {{ else }}
+        emptyDir: {}
         {{ end }}

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -80,7 +80,6 @@ spec:
   type: NodePort
 {{ end }}
 
-{{ if .Values.usePersistentVolumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -93,7 +92,6 @@ spec:
   resources:
     requests:
       storage: {{ .Values.esGrafanaVolumeSize }}
-{{ end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -163,7 +161,7 @@ spec:
         configMap:
           name: grafana-datasource-cm
       - name: grafana-data
-        {{ if .Values.usePersistentVolumes }}
+        {{ if or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes) }}
         persistentVolumeClaim:
           claimName: es-grafana-storage
         {{ else }}

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -40,7 +40,6 @@ subjects:
   name: prometheus-server
   namespace: {{.Release.Namespace}}
 
-{{ if .Values.usePersistentVolumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -67,7 +66,6 @@ spec:
     requests:
       storage: {{ .Values.prometheusVolumeSize }}
 
-{{ end }}
 ---
 kind: Deployment
 apiVersion: {{ .Values.deploymentApiVersion }}
@@ -211,14 +209,14 @@ spec:
           configMap:
             name: es-monitor-api
         - name: monitor-data-volume
-          {{ if .Values.usePersistentVolumes }}
+          {{ if or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes) }}
           persistentVolumeClaim:
             claimName: es-monitor-storage
           {{ else }}
           emptyDir: {}
           {{ end }}
         - name: prometheus-data-volume
-          {{ if .Values.usePersistentVolumes }}
+          {{ if or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes) }}
           persistentVolumeClaim:
             claimName: prometheus-storage
           {{ else }}

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -40,7 +40,7 @@ subjects:
   name: prometheus-server
   namespace: {{.Release.Namespace}}
 
-{{ if not .Values.useEmptyDirVolumes }}
+{{ if .Values.usePersistentVolumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
@@ -211,18 +211,18 @@ spec:
           configMap:
             name: es-monitor-api
         - name: monitor-data-volume
-          {{ if .Values.useEmptyDirVolumes }}
-          emptyDir: {}
-          {{ else }}
+          {{ if .Values.usePersistentVolumes }}
           persistentVolumeClaim:
             claimName: es-monitor-storage
+          {{ else }}
+          emptyDir: {}
           {{ end }}
         - name: prometheus-data-volume
-          {{ if .Values.useEmptyDirVolumes }}
-          emptyDir: {}
-          {{ else }}
+          {{ if .Values.usePersistentVolumes }}
           persistentVolumeClaim:
             claimName: prometheus-storage
+          {{ else }}
+          emptyDir: {}
           {{ end }}
         - name: bare-prometheus
           configMap:

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -58,6 +58,8 @@ prometheusMemoryRequest: 250Mi
 #################################################
 # Persistent Volumes
 #
+# Deprecated value - set to false to disable emptyDir and use persistent volumes. Prefer `usePersistentVolumes`.
+useEmptyDirVolumes: true
 # Set to true to use persistent volumes, otherwise emptyDir volumes are used.
 usePersistentVolumes: false
 # Default StorageClass to use for persistent volumes

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -59,7 +59,7 @@ prometheusMemoryRequest: 250Mi
 # Persistent Volumes
 #
 # Set to true to use emptyDir for all volumes, disabling persistent volumes.
-useEmptyDirVolumes: false
+useEmptyDirVolumes: true
 # Default StorageClass to use for persistent volumes
 defaultStorageClass: standard
 # Prometheus volume size - used for storing metrics data.

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -58,8 +58,8 @@ prometheusMemoryRequest: 250Mi
 #################################################
 # Persistent Volumes
 #
-# Set to true to use emptyDir for all volumes, disabling persistent volumes.
-useEmptyDirVolumes: true
+# Set to true to use persistent volumes, otherwise emptyDir volumes are used.
+usePersistentVolumes: false
 # Default StorageClass to use for persistent volumes
 defaultStorageClass: standard
 # Prometheus volume size - used for storing metrics data.


### PR DESCRIPTION
To make it easier to get started on development clusters and minishift.

Also changes flag to `usePersistentVolumes`.