### PR TITLE
Fix slack template for alert name

### DIFF
--- a/enterprise-suite/alertmanager/slack.tmpl
+++ b/enterprise-suite/alertmanager/slack.tmpl
@@ -1,3 +1,3 @@
 {{ define "title.slack" }}{{ .GroupLabels.namespace}}/{{ .GroupLabels.es_workload }} [{{ .Status | toUpper }}][{{ .CommonLabels.severity | toUpper }}]{{ end }}
-{{ define "text.slack" }}{{ range $index, $element := .Alerts }}_{{ .CommonLabels.name }}_
+{{ define "text.slack" }}{{ range .Alerts }}_{{ .Labels.name }}_
 {{ end }}{{- end -}}


### PR DESCRIPTION
It should be using .Labels as we're looping on the .Alerts.