### PR TITLE
Fix persistent volumes for deployed clusters

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: alertmanager-storage
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   storageClassName: {{ default .Values.defaultStorageClass .Values.esAlertmanagerStorageClass }}
   accessModes:

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -85,6 +85,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: es-grafana-storage
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   storageClassName: {{ default .Values.defaultStorageClass .Values.esGrafanaStorageClass }}
   accessModes:

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -91,10 +91,12 @@ spec:
     spec:
       serviceAccountName: prometheus-server
 
-      {{ if .Values.podUID }}
       securityContext:
+      {{ if .Values.podUID }}
         runAsUser: {{ .Values.podUID }}
       {{ end }}
+        # Needed so the prometheus data volume is write-able. The official prometheus image runs with gid 65534.
+        fsGroup: 65534
 
       initContainers:
         - name: setup
@@ -171,29 +173,35 @@ spec:
 
         - name: prometheus-server
           image: prom/prometheus:{{ .Values.prometheusVersion }}
+
           resources:
             requests:
               cpu: {{ default .Values.defaultCPURequest .Values.prometheusCPURequest }}
               memory: {{ default .Values.defaultMemoryRequest .Values.prometheusMemoryRequest }}
+
           args:
             - --config.file=/etc/config/prometheus.yml
             - --storage.tsdb.path=/data
             - --web.console.libraries=/etc/prometheus/console_libraries
             - --web.console.templates=/etc/prometheus/consoles
             - --web.enable-lifecycle
+
           ports:
             - containerPort: 9090
+
           readinessProbe:
             httpGet:
               path: /-/ready
               port: 9090
             timeoutSeconds: 30
+
           livenessProbe:
             httpGet:
               path: /-/healthy
               port: 9090
             timeoutSeconds: 30
             initialDelaySeconds: 30
+
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -45,6 +45,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: prometheus-storage
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   storageClassName: {{ default .Values.defaultStorageClass .Values.prometheusStorageClass }}
   accessModes:
@@ -82,8 +84,6 @@ spec:
       {{ if .Values.podUID }}
         runAsUser: {{ .Values.podUID }}
       {{ end }}
-        # Needed so the prometheus data volume is write-able. The official prometheus image runs with gid 65534.
-        fsGroup: 65534
 
       initContainers:
         - name: setup
@@ -103,6 +103,19 @@ spec:
               name: config-volume
             - mountPath: /etc/bare
               name: bare-prometheus
+
+        # For vanilla K8s clusters, we need to match prometheus-data permissions to the prometheus user.
+        # In prometheus 2.x, this is `65534`.
+        # For Openshift the below will fail, but we can safely ignore it as Openshift remaps the user itself.
+        - name: change-prometheus-data-volume-ownership
+          image: busybox
+          command:
+            - sh
+            - -c
+            - "chown -Rc :65534 /data || true"
+          volumeMounts:
+            - name: prometheus-data-volume
+              mountPath: /data/prometheus-data
 
       imagePullSecrets:
         - name: commercial-credentials

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -112,10 +112,11 @@ spec:
           command:
             - sh
             - -c
-            - "chown -Rc :65534 /data || true"
+            - "chown -Rc 65534:65534 /data || true"
           volumeMounts:
             - name: prometheus-data-volume
-              mountPath: /data/prometheus-data
+              mountPath: /data
+              subPath: prometheus-data
 
       imagePullSecrets:
         - name: commercial-credentials

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -44,19 +44,6 @@ subjects:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: es-monitor-storage
-spec:
-  storageClassName: {{ default .Values.defaultStorageClass .Values.esMonitorStorageClass }}
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.esMonitorVolumeSize }}
-
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
   name: prometheus-storage
 spec:
   storageClassName: {{ default .Values.defaultStorageClass .Values.prometheusStorageClass }}
@@ -140,8 +127,9 @@ spec:
               mountPath: /etc/config
             - name: es-monitor-api-volume
               mountPath: /etc/es-monitor-api
-            - name: monitor-data-volume
+            - name: prometheus-data-volume
               mountPath: /monitor-data
+              subPath: monitor-data
           ports:
             - containerPort: 8180
           readinessProbe:
@@ -208,6 +196,7 @@ spec:
               readOnly: true
             - name: prometheus-data-volume
               mountPath: /data
+              subPath: prometheus-data
 
       terminationGracePeriodSeconds: 300
       volumes:
@@ -216,13 +205,6 @@ spec:
         - name: es-monitor-api-volume
           configMap:
             name: es-monitor-api
-        - name: monitor-data-volume
-          {{ if or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes) }}
-          persistentVolumeClaim:
-            claimName: es-monitor-storage
-          {{ else }}
-          emptyDir: {}
-          {{ end }}
         - name: prometheus-data-volume
           {{ if or .Values.usePersistentVolumes (not .Values.useEmptyDirVolumes) }}
           persistentVolumeClaim:

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -66,8 +66,6 @@ usePersistentVolumes: false
 defaultStorageClass: standard
 # Prometheus volume size - used for storing metrics data.
 prometheusVolumeSize: 256Gi
-# ES Monitor API volume size - used for storing monitors in a git repo.
-esMonitorVolumeSize: 32Gi
 # Alertmanager volume size - used for storing silences.
 alertmanagerVolumeSize: 32Gi
 # Grafana volume size - used for storing users, custom dashboards, and plugins.


### PR DESCRIPTION
Fix several bugs around the PVC setup:
- PVCs can get mounted as 755, so only root users can write to them. On non-openshift clusters, prometheus runs with uid:gid 65534:65534, so gets permission denied when trying to write to the volume. I've added an init container that sets the permissions as needed. We can't use `fsGroup` because it doesn't work on Openshift.
- Can't have more than one PVC per pod - as they could be created on different availability zones, which would prevent the pod from being scheduled. So I've had to consolidate the monitor-data-volume and prometheus-data-volume into a single PVC.
- Add annotation to prevent helm from deleting the PVCs, to prevent data loss for customers.

Unfortunately this is a breaking change due to the need to consolidate the PVCs. But there is no way around this as far as I can see. Given the broken state of PVCs right now I think it's okay/necessary.