### PR TITLE
Add --devel flag so helm can see rc.x versions

### DIFF
--- a/enterprise-suite/scripts/install-es.sh
+++ b/enterprise-suite/scripts/install-es.sh
@@ -196,7 +196,7 @@ if [ "false" != "$ES_EXPORT_YAML" ]; then
 
     if [ -z "$ES_LOCAL_CHART" ]; then
         TDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'install-es-tdir')
-        debug helm fetch -d $TDIR "$VERSION_ARG" "$chart_ref"
+        debug helm fetch -d $TDIR --devel "$VERSION_ARG" "$chart_ref"
         chart_ref=$TDIR/${ES_CHART}*.tgz
     fi
     debug -o 1 helm template --name "$ES_HELM_NAME" --namespace "$ES_NAMESPACE" \
@@ -222,11 +222,11 @@ else
     import_credentials
 
     if [ "true" == "$should_upgrade" ]; then
-        debug helm upgrade "$ES_HELM_NAME" "$chart_ref" \
+        debug helm upgrade "$ES_HELM_NAME" "$chart_ref" --devel \
             "$HELM_CREDENTIALS_VALUES" \
             "$@"
     else
-        debug helm install "$chart_ref" --name "$ES_HELM_NAME" --namespace "$ES_NAMESPACE" \
+        debug helm install "$chart_ref" --devel --name "$ES_HELM_NAME" --namespace "$ES_NAMESPACE" \
             "$HELM_CREDENTIALS_VALUES" \
             "$@"
     fi

--- a/enterprise-suite/tests/install-es.bats
+++ b/enterprise-suite/tests/install-es.bats
@@ -52,13 +52,13 @@ function setup {
 
 @test "helm install command" {
     run $install_es
-    assert_output --regexp '.*helm install es-repo/enterprise-suite --name myhelmname --namespace lightbend --values [^ ]*creds\..*'
+    assert_output --regexp '.*helm install es-repo/enterprise-suite --devel --name myhelmname --namespace lightbend --values [^ ]*creds\..*'
 }
 
 @test "helm upgrade command if chart exists" {
     ES_STUB_CHART_STATUS="0" \
         run $install_es
-    assert_output --regexp '.*helm upgrade myhelmname es-repo/enterprise-suite --values [^ ]*creds\..*'
+    assert_output --regexp '.*helm upgrade myhelmname es-repo/enterprise-suite --devel --values [^ ]*creds\..*'
 }
 
 @test "export console yaml with '--version blah'" {


### PR DESCRIPTION
Unbelievably (to me at least) helm ignores by default versions that look like `a.b.c.d-e`.  This means that the install script is currently ignoring our release candidates (e.g. `1.0.0-rc.3`).

c.f. https://github.com/helm/helm/issues/2407

Adding the `--devel` flag will pick them up.