### PR TITLE
Don't use metric_relabel_rules

### DIFF
--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -50,6 +50,7 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_node_address_InternalIP]
         target_label: node_ip
 
+    # These are explicitly metric_label_configs so they don't affect automatic metrics (up, scrape_time_duration, etc.).
     metric_relabel_configs:
       - source_labels: [pod_name]
         target_label: kubernetes_pod_name
@@ -117,7 +118,10 @@ scrape_configs:
         action: replace
         target_label: node_ip
 
+{{ .MonitorTypeRules | indent 6 }}
+
     # es_workload labels:
+    # These are explicitly metric_label_configs so they don't affect automatic metrics (up, scrape_time_duration, etc.).
     metric_relabel_configs:
       - source_labels: [created_by_kind, pod, es_workload]
         regex: 'ReplicaSet;(.+)-[^-]+-[^-]+;'
@@ -159,9 +163,6 @@ scrape_configs:
       - source_labels: [pod, es_workload]
         regex: (.+);
         target_label: es_workload
-
-{{ .MonitorTypeRules | indent 6 }}
-
 
   - job_name: 'node-exporter'
     kubernetes_sd_configs:
@@ -277,7 +278,6 @@ scrape_configs:
         regex: '(.*)-[0-9]+;'
         target_label: es_workload
 
-    metric_relabel_configs:
 {{ .MonitorTypeRules | indent 6 }}
 
 
@@ -357,5 +357,4 @@ scrape_configs:
         regex: '(.*)-[0-9]+;'
         target_label: es_workload
 
-    metric_relabel_configs:
 {{ .MonitorTypeRules | indent 6 }}

--- a/enterprise-suite/es-monitor-api/prometheus.yml
+++ b/enterprise-suite/es-monitor-api/prometheus.yml
@@ -50,7 +50,7 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_node_address_InternalIP]
         target_label: node_ip
 
-    # These are explicitly metric_label_configs so they don't affect automatic metrics (up, scrape_time_duration, etc.).
+    # These are metric_label_configs since the source labels come from the scraped `/metrics`.
     metric_relabel_configs:
       - source_labels: [pod_name]
         target_label: kubernetes_pod_name
@@ -118,10 +118,8 @@ scrape_configs:
         action: replace
         target_label: node_ip
 
-{{ .MonitorTypeRules | indent 6 }}
-
     # es_workload labels:
-    # These are explicitly metric_label_configs so they don't affect automatic metrics (up, scrape_time_duration, etc.).
+    # These are metric_label_configs since the source labels come from the scraped `/metrics`.
     metric_relabel_configs:
       - source_labels: [created_by_kind, pod, es_workload]
         regex: 'ReplicaSet;(.+)-[^-]+-[^-]+;'
@@ -163,6 +161,8 @@ scrape_configs:
       - source_labels: [pod, es_workload]
         regex: (.+);
         target_label: es_workload
+
+{{ .MonitorTypeRules | indent 6 }}
 
   - job_name: 'node-exporter'
     kubernetes_sd_configs:


### PR DESCRIPTION
They don't capture automatic metrics (up, scrape_duration_time, etc.).
As a result, we can't create custom monitors on any of these metrics -
as they don't get `es_monitor_type`.

We are using metric_relabel_rules as a way to avoid labeling automatic
metrics in some cases (cadvisor/kube_state_metrics), so I've kept these
in place. However, I think it might be better if we just fixed the rules
to handle automatic metrics as it's not obvious. For now I've added a
comment.

For https://github.com/lightbend/es-backend/issues/408