### PR TITLE
Make cluster roles optional and namespace binding

### DIFF
--- a/enterprise-suite/templates/kube-state-metrics.yaml
+++ b/enterprise-suite/templates/kube-state-metrics.yaml
@@ -1,5 +1,5 @@
-
 ---
+{{ if .Values.createClusterRole }}
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRole
 metadata:
@@ -39,11 +39,12 @@ rules:
   resources:
   - horizontalpodautoscalers
   verbs: ["list", "watch"]
+{{ end }}
 ---
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-kube-state-metrics
+  name: {{.Release.Namespace}}:prometheus-kube-state-metrics
 roleRef:
   apiGroup: {{ .Values.apiGroupVersion }}
   kind: ClusterRole

--- a/enterprise-suite/templates/kube-state-metrics.yaml
+++ b/enterprise-suite/templates/kube-state-metrics.yaml
@@ -1,5 +1,5 @@
 ---
-{{ if .Values.createClusterRole }}
+{{ if .Values.createClusterRoles }}
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRole
 metadata:

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -5,6 +5,7 @@ metadata:
   name: prometheus-server
 
 ---
+{{ if .Values.createClusterRole }}
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRole
 metadata:
@@ -25,12 +26,12 @@ rules:
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
-
+{{ end }}
 ---
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus-server
+  name: {{.Release.Namespace}}:prometheus-server
 roleRef:
   apiGroup: {{ .Values.apiGroupVersion }}
   kind: ClusterRole

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -5,7 +5,7 @@ metadata:
   name: prometheus-server
 
 ---
-{{ if .Values.createClusterRole }}
+{{ if .Values.createClusterRoles }}
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRole
 metadata:

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -49,8 +49,7 @@ alertManagerConfigMap: alertmanager-default
 #################################################
 # RBAC
 #
-# Create ClusterRoles for RBAC.
-# Set to false if creating additional Lightbend Consoles in the same cluster, as this is a shared resource.
+# Create ClusterRoles for RBAC, used by Prometheus for service discovery and kube-state-metrics. Set to false if creating additional Lightbend Consoles in the same cluster, as this is a shared resource.
 createClusterRoles: true
 
 #################################################

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -45,6 +45,14 @@ imageCredentials:
 # Alertmanager ConfigMap. Set to the name of a ConfigMap, with a file `alertmanager.yml`.
 alertManagerConfigMap: alertmanager-default
 
+
+#################################################
+# RBAC
+#
+# Create ClusterRoles for RBAC.
+# Set to false if creating additional Lightbend Consoles in the same cluster, as this is a shared resource.
+createClusterRoles: true
+
 #################################################
 # ResourceRequests
 #


### PR DESCRIPTION
This allows us to install multiple Consoles into the same cluster,
by passing `createClusterRoles=false` as a helm parameter.