### PR TITLE
Make images configurable in a consistent way

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: prometheus-alertmanager
-          image: prom/alertmanager:{{ .Values.alertManagerVersion }}
+          image: {{ .Values.alertManagerImage }}:{{ .Values.alertManagerVersion }}
           resources:
             requests:
               cpu: {{ default .Values.defaultCPURequest .Values.alertManagerCPURequest }}
@@ -76,7 +76,7 @@ spec:
               mountPath: /data
 
         - name: prometheus-alertmanager-configmap-reload
-          image: jimmidyson/configmap-reload:{{ .Values.configMapReloadVersion }}
+          image: {{ .Values.configMapReloadImage }}:{{ .Values.configMapReloadVersion }}
           resources:
             requests:
               cpu: {{ default .Values.defaultCPURequest .Values.configmapReloadCPURequest }}

--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -20,14 +20,14 @@ spec:
 
       containers:
       - name: dnsmasq
-        image: "janeczku/go-dnsmasq:release-1.0.7"
+        image: {{ .Values.goDnsmasqImage }}:{{ .Values.goDnsmasqVersion }}
         args:
           - --listen
           - "127.0.0.1:5353"
           - --verbose
           - --enable-search
       - name: es-console
-        image: {{ .Values.imageCredentials.registry }}/enterprise-suite/es-console:{{ .Values.esConsoleVersion }}
+        image: {{ tpl .Values.esConsoleImage . }}:{{ .Values.esConsoleVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         resources:
           requests:

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -120,7 +120,7 @@ spec:
       - name: commercial-credentials
 
       containers:
-      - image: {{ .Values.imageCredentials.registry }}/enterprise-suite/es-grafana:{{ .Values.esGrafanaVersion }}
+      - image: {{ tpl .Values.esGrafanaImage . }}:{{ .Values.esGrafanaVersion }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         name: grafana-server
         resources:

--- a/enterprise-suite/templates/kube-state-metrics.yaml
+++ b/enterprise-suite/templates/kube-state-metrics.yaml
@@ -86,7 +86,7 @@ spec:
       serviceAccountName: prometheus-kube-state-metrics
       containers:
         - name: prometheus-kube-state-metrics
-          image: "gcr.io/google_containers/kube-state-metrics:{{ .Values.kubeStateMetricsVersion }}"
+          image: {{ .Values.kubeStateMetricsImage }}:{{ .Values.kubeStateMetricsVersion }}
           args:
             - --port=8080
             - --telemetry-port=8081

--- a/enterprise-suite/templates/node-exporter.yaml
+++ b/enterprise-suite/templates/node-exporter.yaml
@@ -31,7 +31,7 @@ spec:
       {{ end }}
       containers:
         - name: prometheus-node-exporter
-          image: "prom/node-exporter:{{ .Values.nodeExporterVersion }}"
+          image: {{ .Values.nodeExporterImage }}:{{ .Values.nodeExporterVersion }}
           resources:
             requests:
               cpu: {{ default .Values.defaultCPURequest .Values.nodeExporterCPURequest }}

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -87,7 +87,7 @@ spec:
 
       initContainers:
         - name: setup
-          image: alpine
+          image: {{ .Values.alpineImage }}:{{ .Values.alpineVersion }}
           resources:
             requests:
               cpu: {{ default .Values.defaultCPURequest }}
@@ -108,7 +108,7 @@ spec:
         # In prometheus 2.x, this is `65534`.
         # For Openshift the below will fail, but we can safely ignore it as Openshift remaps the user itself.
         - name: change-prometheus-data-volume-ownership
-          image: busybox
+          image: {{ .Values.busyboxImage }}:{{ .Values.busyboxVersion }}
           command:
             - sh
             - -c
@@ -123,7 +123,7 @@ spec:
 
       containers:
         - name: es-monitor-api
-          image: {{ .Values.imageCredentials.registry }}/enterprise-suite/es-monitor-api:{{ .Values.esMonitorVersion }}
+          image: {{ tpl .Values.esMonitorImage . }}:{{ .Values.esMonitorVersion }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           resources:
             requests:
@@ -161,7 +161,7 @@ spec:
             initialDelaySeconds: 30
 
         - name: es-monitor-api-configmap-reload
-          image: jimmidyson/configmap-reload:{{ .Values.configMapReloadVersion }}
+          image: {{ .Values.configMapReloadImage }}:{{ .Values.configMapReloadVersion }}
           resources:
             requests:
               cpu: {{ default .Values.defaultCPURequest .Values.configmapReloadCPURequest }}
@@ -174,7 +174,7 @@ spec:
             mountPath: /etc/es-monitor-api
 
         - name: prometheus-server
-          image: prom/prometheus:{{ .Values.prometheusVersion }}
+          image: {{ .Values.prometheusImage }}:{{ .Values.prometheusVersion }}
 
           resources:
             requests:

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -20,9 +20,9 @@ nodeExporterVersion: v0.15.2
 # janeczku/go-dnsmasq
 goDnsmasqVersion: release-1.0.7
 # alpine
-alpineVersion: latest
+alpineVersion: 3.8
 # busybox
-busyboxVersion: latest
+busyboxVersion: 1.29
 
 #################################################
 # Image names to use. Combined with the versions above, gives the fully qualified docker image name.

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -17,6 +17,38 @@ configMapReloadVersion: v0.2.2
 kubeStateMetricsVersion: v1.2.0
 # prom/node-exporter
 nodeExporterVersion: v0.15.2
+# janeczku/go-dnsmasq
+goDnsmasqVersion: release-1.0.7
+# alpine
+alpineVersion: latest
+# busybox
+busyboxVersion: latest
+
+#################################################
+# Image names to use. Combined with the versions above, gives the fully qualified docker image name.
+#
+# es-console image
+esConsoleImage: '{{ .Values.imageCredentials.registry }}/enterprise-suite/es-console'
+# es-monitor-api image
+esMonitorImage: '{{ .Values.imageCredentials.registry }}/enterprise-suite/es-monitor-api'
+# es-grafana image
+esGrafanaImage: '{{ .Values.imageCredentials.registry }}/enterprise-suite/es-grafana'
+# prometheus image
+prometheusImage: prom/prometheus
+# alertmanager image
+alertManagerImage: prom/alertmanager
+# configmap-reload image
+configMapReloadImage: jimmidyson/configmap-reload
+# kube-state-metrics image
+kubeStateMetricsImage: gcr.io/google_containers/kube-state-metrics
+# node-exporter image
+nodeExporterImage: prom/node-exporter
+# go-dnsmasq image
+goDnsmasqImage: janeczku/go-dnsmasq
+# alpine image
+alpineImage: alpine
+# busybox image
+busyboxImage: busybox
 
 #################################################
 # Kubernetes Api Versions
@@ -42,6 +74,7 @@ imageCredentials:
   registry: lightbend-docker-commercial-registry.bintray.io
 #  username: setme
 #  password: setme
+
 # Alertmanager ConfigMap. Set to the name of a ConfigMap, with a file `alertmanager.yml`.
 alertManagerConfigMap: alertmanager-default
 


### PR DESCRIPTION
This is per https://docs.helm.sh/chart_best_practices/, but also has
other benefits:
- For airgapped installs, we can specify a differerent location for all
of the images.
- For the openshift registry we can provide different image names.
- Makes it clear all of our image dependencies in one place.