### PR TITLE
Timeout tests after 90s (default)

### DIFF
--- a/enterprise-suite/tests/smoke_nginx
+++ b/enterprise-suite/tests/smoke_nginx
@@ -21,8 +21,11 @@ test_alertmanager_responding "$BASEPATH/service/alertmanager/"
 #
 
 test_redirect() {
-    redir=$( curl_headers "$1" | awk '$1=="Location:"{print $2}' )
-    [[ $redir == "$2" ]]
+    redirect () {
+      redir=$( curl_headers "$1" | awk '$1=="Location:"{print $2}' )
+      [[ $redir == "$2" ]]
+    }
+    timeout redirect "$@"
     T $? "$1" redirects to "$2"
 }
 test_redirect "${CONSOLE}/service/prometheus"   "/service/prometheus/"
@@ -34,8 +37,11 @@ test_redirect "${CONSOLE}/service/alertmanager" "/service/alertmanager/"
 #
 
 test_no_cache() {
-    cache_control=$( curl_headers "$1" | awk -F ': ' '$1=="Cache-Control"{print $2}' )
-    [[ $cache_control == "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" ]]
+    no_cache() {
+      cache_control=$( curl_headers "$1" | awk -F ': ' '$1=="Cache-Control"{print $2}' )
+      [[ $cache_control == "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" ]]
+    }
+    timeout no_cache "$@"
     T $? "$1" has cache control
 }
 

--- a/enterprise-suite/tests/smoke_prometheus
+++ b/enterprise-suite/tests/smoke_prometheus
@@ -25,14 +25,20 @@ prom_query() {
 }
 
 prom_has_data() {
-  results=$( prom_query "$@" | jq '.data.result | length' )
-  ! [[ results -eq 0 ]]
+  test_prom_has_data () {
+    results=$( prom_query "$@" | jq '.data.result | length' )
+    ! [[ results -eq 0 ]]
+  }
+  timeout test_prom_has_data "$@"
   T $? timeseries: "$*"
 }
 
 prom_has_no_data() {
-  results=$( prom_query "$@" | jq '.data.result | length' )
-  [[ results -eq 0 ]]
+  test_prom_has_data () {
+    results=$( prom_query "$@" | jq '.data.result | length' )
+    [[ results -eq 0 ]]
+  }
+  timeout test_prom_has_data "$@"
   T $? timeseries: "$*"
 }
 

--- a/enterprise-suite/tests/smokecommon
+++ b/enterprise-suite/tests/smokecommon
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Note that parts of this depend on minikube at this time.
 
 #set -x
@@ -8,6 +6,8 @@
 #set -e
 set -o pipefail
 set -o nounset
+
+source timeout.fn
 
 : "${CURRENT_CONTEXT:=minikube}"
 
@@ -32,8 +32,37 @@ busy_wait() {
   done
 }
 
-TEST_SUCCESSES=0
-TEST_FAILURES=0
+timeout() {
+    # default timeout is 90s.  If $1 is a number, it will be used as timeout value
+    timeout=90
+    re='^[0-9]+$'
+    if [[ "$1" =~ $re ]] ; then
+        timeout=$1
+        shift
+    fi
+    timeout_function $timeout "$@"
+}
+
+
+# Setup fds for writing/reading success/failure counts.  Allows things to work across subshells
+SUCCESSES=$(mktemp -t pipe.XXXXX)
+exec 3>$SUCCESSES
+exec 4<$SUCCESSES
+# unlink so we don't have to clean up later
+rm $SUCCESSES
+
+FAILURES=$(mktemp -t pipe.XXXXX)
+exec 6>$FAILURES
+exec 7<$FAILURES
+# unlink so we don't have to clean up later
+rm $FAILURES
+
+TIMEOUTS=$(mktemp -t pipe.XXXXX)
+exec 8>$TIMEOUTS
+exec 9<$TIMEOUTS
+# unlink so we don't have to clean up later
+rm $TIMEOUTS
+
 
 # test runner
 # command to test &&:
@@ -44,21 +73,36 @@ T() {
   msg="$*"
   if [[ 0 -eq res ]]; then
     echo "PASS: $msg"
-    ((++TEST_SUCCESSES))
+    echo 1 >&3
   else
+    if [[ 142 -eq res ]]; then
+        echo "*** TIMEOUT: $msg"
+        echo 1 >&8
+    fi
     echo "*** FAIL: $msg"
+    echo 1 >&6
     # make it conditional on a cli arg whether we bail or not
-    ((++TEST_FAILURES))
     # error "test failed"
   fi
 }
 
 # Note that this function calls exit, so should be last command in (sub)shell
 test_summary() {
+    # Close success/failure pipes for writing so we can read them
+    exec 3>&-
+    TEST_SUCCESSES=$( awk '{successes += $1} END {print successes}' <&4 )
+    : ${TEST_SUCCESSES:=0}
+    exec 6>&-
+    TEST_FAILURES=$( awk '{failures += $1} END {print failures}' <&7 )
+    : ${TEST_FAILURES:=0}
+    exec 8>&-
+    TEST_TIMEOUTS=$( awk '{timeouts += $1} END {print timeouts}' <&9 )
+    : ${TEST_TIMEOUTS:=0}
+
     if [ $TEST_FAILURES -eq 0 ] ; then
-        echo "All ${0##*/} tests pass.  PASS: $TEST_SUCCESSES  FAIL: 0"
+        echo "All ${0##*/} tests pass.  PASS: $TEST_SUCCESSES  FAIL: 0  (TIMEOUTS: 0)"
     else
-        echo "Some ${0##*/} tests failed!  PASS: $TEST_SUCCESSES  FAIL: $TEST_FAILURES"
+        echo "Some ${0##*/} tests failed!  PASS: $TEST_SUCCESSES  FAIL: $TEST_FAILURES  (TIMEOUTS: $TEST_TIMEOUTS)"
     fi
 
     exit $TEST_FAILURES
@@ -90,7 +134,7 @@ curl_headers() {
 
 # Used with busy_wait to determine if the console is ready for requests
 es_console_ready() {
-	[ "Running" = $(kubectl get pod -l run=es-console -n lightbend -o go-template --template="{{ (index .items 0).status.phase }}") ]
+    [ "Running" = $(kubectl get pod -l run=es-console -n lightbend -o go-template --template="{{ (index .items 0).status.phase }}") ]
 }
 
 # Lightbend Console access test
@@ -98,33 +142,48 @@ es_console_ready() {
 test_es_console_responding() {
   CONSOLE_URL=$1
   shift
-  results=$( curl_query $CONSOLE_URL "" "$@" | fgrep -q '<title>Enterprise Suite Reactive Console</title>' )
+  es_console_responding() {
+      curl_query $CONSOLE_URL "" "$@" | fgrep -q '<title>Enterprise Suite Reactive Console</title>'
+  }
+  timeout es_console_responding "$@"
   T $? Lightbend Console accessible via $CONSOLE_URL "$@"
 }
 
 # Grafana access test
 test_grafana_responding() {
-  results=$( curl_query $1 "api/org" | jq '.id' )
-  ! [[ $results -eq 0 ]]
+  grafana_responding() {
+      results=$(curl_query $1 "api/org" | jq '.id')
+      ! [[ $results -eq 0 ]]
+  }
+  timeout grafana_responding "$@"
   T $? grafana service accessible via $1
 }
 
 # Prometheus access test
 test_prom_responding() {
-  status=$( curl_query $1 "api/v1/status/config" | jq '.status' )
-  [[ $status = '"success"' ]]
+  prom_responding() {
+      status=$( curl_query $1 "api/v1/status/config" | jq '.status' )
+      [[ $status = '"success"' ]]
+  }
+  timeout prom_responding "$@"
   T $? prometheus service accessible via $1
 }
 
 # ES monitor API access test
 test_es_monitor_API_responding() {
-  status=$( curl_query $1 "status" | jq '.status' )
-  [[ $status = '"success"' ]]
+  es_monitor_API_responding() {
+      status=$( curl_query $1 "status" | jq '.status' )
+      [[ $status = '"success"' ]]
+  }
+  timeout es_monitor_API_responding "$@"
   T $? es-monitor-api service accessible via $1
 }
 
 # Alertmanager access test
 test_alertmanager_responding() {
-  results=$( curl_query $1 "" | fgrep -q '<title>Alertmanager</title>' )
+  alertmanager_responding() {
+      results=$( curl_query $1 "" | fgrep -q '<title>Alertmanager</title>' )
+  }
+  timeout alertmanager_responding "$@"
   T $? alertmanager accessible via $1
 }

--- a/enterprise-suite/tests/timeout.fn
+++ b/enterprise-suite/tests/timeout.fn
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Execute a command with a timeout
+
+# This has been modified so that it's a function instead of a command.
+# Also return 142 on timeout to match "kill SIGALARM" return value.
+
+# License: LGPLv2
+# Author:
+#    http://www.pixelbeat.org/
+# Notes:
+#    Note there is a timeout command packaged with coreutils since v7.0
+#    If the timeout occurs the exit status is 124.
+#    There is an asynchronous (and buggy) equivalent of this
+#    script packaged with bash (under /usr/share/doc/ in my distro),
+#    which I only noticed after writing this.
+#    I noticed later again that there is a C equivalent of this packaged
+#    with satan by Wietse Venema, and copied to forensics by Dan Farmer.
+# Changes:
+#    V1.0, Nov  3 2006, Initial release
+#    V1.1, Nov 20 2007, Brad Greenlee <brad@footle.org>
+#                       Make more portable by using the 'CHLD'
+#                       signal spec rather than 17.
+#    V1.3, Oct 29 2009, Ján Sáreník <jasan@x31.com>
+#                       Even though this runs under dash,ksh etc.
+#                       it doesn't actually timeout. So enforce bash for now.
+#                       Also change exit on timeout from 128 to 124
+#                       to match coreutils.
+#    V2.0, Oct 30 2009, Ján Sáreník <jasan@x31.com>
+#                       Rewritten to cover compatibility with other
+#                       Bourne shell implementations (pdksh, dash)
+
+#set -x
+
+a=
+
+timeout_cleanup()
+{
+    trap - ALRM                #reset handler to default
+    kill -ALRM $a 2>/dev/null  #stop timer subshell if running
+    last=$!
+    kill $last 2>/dev/null &&  #kill last job
+      return 142               #exit with 142 if it was running
+}
+
+timeout_watchit()
+{
+    trap "timeout_cleanup" ALRM
+    sleep $1 & wait
+    kill -ALRM $$
+}
+
+timeout_function()
+{
+    if [ "$#" -lt "2" ]; then
+        echo "Usage:   `basename $0` timeout_in_seconds command" >&2
+        echo "Example: `basename $0` 2 sleep 3 || echo timeout" >&2
+        return 1
+    fi
+
+    timeout_watchit $1 & a=$!        #start the timeout
+    shift                            #first param was timeout for sleep
+    trap "timeout_cleanup" ALRM INT  #cleanup after timeout
+    "$@" & wait $! ; RET=$?          #start the job wait for it and save its return value
+    kill -ALRM $a                    #send ALRM signal to timeout_watchit
+    wait $a                          #wait for timeout_watchit to finish cleanup
+    return $RET                      #return the value
+}


### PR DESCRIPTION
Added a `timeout` function for running tests.  Default is 90s.  If nothing times out, then behavior is unchanged.  If there's a timeout, then the FAILURES are incremented, and also tracked as a timeout failure.

For example, I hacked the following change to `smokecommon`:
```
@@ -152,10 +152,11 @@ test_es_console_responding() {
 # Grafana access test
 test_grafana_responding() {
   grafana_responding() {
+      sleep 4
       results=$(curl_query $1 "api/org" | jq '.id')
       ! [[ $results -eq 0 ]]
   }
-  timeout grafana_responding "$@"
+  timeout 1 grafana_responding "$@"
   T $? grafana service accessible via $1
 }
```

That forced the `test_grafana_responding` test to take at least 4 seconds.  Note also that I specified a non-default timeout of 1 second for this test.  The output from running `smoke_services` looked like:

```
PASS: Lightbend Console accessible via http://192.168.99.100:30080
*** TIMEOUT: grafana service accessible via http://192.168.99.100:30030
*** FAIL: grafana service accessible via http://192.168.99.100:30030
./smoke_services: line 23: 84374 Terminated: 15          "$@"
PASS: prometheus service accessible via http://192.168.99.100:30090
PASS: alertmanager accessible via http://192.168.99.100:30093
*** TIMEOUT: grafana service accessible via http://192.168.99.100:30080/service/grafana
*** FAIL: grafana service accessible via http://192.168.99.100:30080/service/grafana
./smoke_services: line 27: 84392 Terminated: 15          "$@"
PASS: prometheus service accessible via http://192.168.99.100:30080/service/prometheus
PASS: es-monitor-api service accessible via http://192.168.99.100:30080/service/es-monitor-api
Some smoke_services tests failed!  PASS: 5  FAIL: 2  (TIMEOUTS: 2)
```