### PR TITLE
Improvements for lbc.py

### DIFF
--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -121,12 +121,12 @@ HELM_VALUES_FLAG=$(if $(HELM_VALUES_FILE),--values $(HELM_VALUES_FILE))
 install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm  ## Install local tarball
 	# We set a podUID here for test purposes to ensure everything works as non-root.
 	# We usePersistentVolumes to ensure PVCs work as expected.
-	-ES_LOCAL_CHART=$(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz \
-	    $(CHART_DIR)/scripts/lbc.py install --wait --set minikube=$(MINIKUBE),podUID=10001,usePersistentVolumes=true -- $(HELM_VALUES_FLAG)
+	-$(CHART_DIR)/scripts/lbc.py install --local-chart=$(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz \
+		--wait --set minikube=$(MINIKUBE),podUID=10001,usePersistentVolumes=true -- $(HELM_VALUES_FLAG)
 
 install-dev: install-helm ## Install content of enterprise-suite/ folder
-	ES_LOCAL_CHART=$(CHART_DIR) \
-	    $(CHART_DIR)/scripts/lbc.py install --wait --set minikube=$(MINIKUBE) -- $(HELM_VALUES_FLAG)
+	-$(CHART_DIR)/scripts/lbc.py install --local-chart=$(CHART_DIR) --wait \
+		--set minikube=$(MINIKUBE) -- $(HELM_VALUES_FLAG)
 
 help:  ## Print help for targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(lastword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/enterprise-suite/Makefile
+++ b/enterprise-suite/Makefile
@@ -33,7 +33,7 @@ package: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz  ## Build chart tarball
 
 script-tests:
 	$(CHART_DIR)/tests/lib/bats/bats $(CHART_DIR)/tests
-	python2 $(CHART_DIR)/scripts/lbc_test.py
+	python $(CHART_DIR)/scripts/lbc_test.py
 
 minikube-tests: build install-local
 	@echo Installed Console from helm charts: $(CHART)
@@ -122,11 +122,11 @@ install-local: $(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz install-helm  ## Install l
 	# We set a podUID here for test purposes to ensure everything works as non-root.
 	# We usePersistentVolumes to ensure PVCs work as expected.
 	-ES_LOCAL_CHART=$(HELM_CHARTS_DIR)/docs/$(RELEASE).tgz \
-	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE),podUID=10001,usePersistentVolumes=true $(HELM_VALUES_FLAG)
+	    $(CHART_DIR)/scripts/lbc.py install --wait --set minikube=$(MINIKUBE),podUID=10001,usePersistentVolumes=true -- $(HELM_VALUES_FLAG)
 
 install-dev: install-helm ## Install content of enterprise-suite/ folder
 	ES_LOCAL_CHART=$(CHART_DIR) \
-	    $(CHART_DIR)/scripts/install-es.sh --wait --set minikube=$(MINIKUBE) $(HELM_VALUES_FLAG)
+	    $(CHART_DIR)/scripts/lbc.py install --wait --set minikube=$(MINIKUBE) -- $(HELM_VALUES_FLAG)
 
 help:  ## Print help for targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(lastword $(MAKEFILE_LIST)) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -252,6 +252,8 @@ def are_pvcs_created(namespace):
         return all_found
     return False
 
+# Returns true if required cluster roles are already created.
+# Exits with an error if some cluster roles are present, but not all.
 def are_cluster_roles_created():
     stdout, returncode = run('kubectl get clusterroles --no-headers')
     if returncode == 0:

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -272,9 +272,14 @@ def are_clusterroles_created():
 
 def install(creds_file):
     creds_arg = '--values ' + creds_file
+    version_arg = ('--version ' + args.version) if args.version != None else '--devel'
+
     # Helm args are separated from lbc.py args by double dash, filter it out
     helm_args = ' '.join([arg for arg in args.helm if arg != '--'])
-    version_arg = ('--version ' + args.version) if args.version != None else '--devel'
+
+    # Add '--set' arguments to helm_args
+    if args.set != None:
+        helm_args += ' '.join(['--set ' + keyval for keyval in args.set])
 
     chart_ref = None
     if args.local_chart != None:
@@ -526,6 +531,8 @@ def setup_args(argv):
     install.add_argument('--repo', help='helm chart repository', default='https://repo.lightbend.com/helm-charts')
     install.add_argument('--creds', help='credentials file', default='~/.lightbend/commercial.credentials')
     install.add_argument('--version', help='console version to install', type=str)
+    install.add_argument('--set', help='set a helm chart value, can be repeated for multiple values', type=str,
+                         action='append')
 
     install.add_argument('helm', help="any additional arguments separated by '--' will be passed to helm (eg. '-- --set emptyDir=false')",
                          nargs=argparse.REMAINDER)

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -80,14 +80,14 @@ def make_tempdir():
 # Returns (stdout, returncode) tuple. If timeout
 # occured, returncode will be negative (-9 on macOS).
 def run(cmd, timeout=None, stdin=None, show_stderr=True):
-    stdout, stderr, returncode = None, None, None
+    stdout, stderr, returncode, timer = None, None, None, None
     try:
         proc = subprocess.Popen(shlex.split(cmd),
                                 stdout=subprocess.PIPE,
                                 stdin=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
-        timer = threading.Timer(timeout, proc.kill) if timeout != None else None 
-        if timer != None:
+        if timeout != None:
+            timer = threading.Timer(timeout, proc.kill) 
             timer.start()
         stdout, stderr = proc.communicate(input=stdin)
         if len(stderr) > 0 and show_stderr:

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -98,6 +98,25 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
 
+    def test_install_helm_failed(self):
+        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
+        expect_cmd(r'helm repo update')
+        expect_cmd(r'helm status enterprise-suite', returncode=0,
+                   stdout='LAST DEPLOYED: Tue Nov 13 09:59:46 2018\nNAMESPACE: lightbend\nSTATUS: FAILED\nNOTES: blah')
+        expect_cmd(r'helm delete --purge enterprise-suite')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
+
+    def test_install_not_finished(self):
+        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
+        expect_cmd(r'helm repo update')
+        expect_cmd(r'helm status enterprise-suite', returncode=0,
+                   stdout='LAST DEPLOYED: Tue Nov 13 09:59:46 2018\nNAMESPACE: lightbend\nSTATUS: PENDING_INSTALL\nNOTES: blah')
+
+        # Expect install to fail when previous install is still pending
+        with self.assertRaises(TestFailException):
+            lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
+
     def test_upgrade(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
@@ -145,6 +164,19 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm status lb-console', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name lb-console --namespace lightbend --devel --values \S+')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--helm-name=lb-console'])
+
+    def test_uninstall(self):
+        expect_cmd(r'helm status enterprise-suite', returncode=0,
+                  stdout='LAST DEPLOYED: Tue Nov 13 09:59:46 2018\nNAMESPACE: lightbend\nSTATUS: DEPLOYED\nNOTES: blah')
+        expect_cmd(r'helm delete --purge enterprise-suite')
+        lbc.main(['uninstall', '--skip-checks'])
+
+    def test_uninstall_not_found(self):
+        expect_cmd(r'helm status enterprise-suite', returncode=-1)
+
+        # Expect uninstall to fail
+        with self.assertRaises(TestFailException):
+            lbc.main(['uninstall', '--skip-checks'])
 
     def test_verify_fail(self):
         expect_cmd(r'kubectl --namespace monitoring get deploy/es-console --no-headers',

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -139,6 +139,13 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --fakearg')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--', '--set', 'minikube=true', '--fakearg'])
 
+    def test_helm_set(self):
+        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
+        expect_cmd(r'helm repo update')
+        expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --set usePersistentVolumes=true')
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'minikube=true', '--set', 'usePersistentVolumes=true'])
+
     def test_specify_version(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 import lbc
 import re

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -150,7 +150,7 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
-        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+ --set minikube=true --set usePersistentVolumes=true')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set minikube=true --set usePersistentVolumes=true')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--set', 'minikube=true', '--set', 'usePersistentVolumes=true'])
 
     def test_specify_version(self):

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -97,6 +97,13 @@ class LbcTest(unittest.TestCase):
         expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
+    
+    def test_install_wait(self):
+        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
+        expect_cmd(r'helm repo update')
+        expect_cmd(r'helm status enterprise-suite', returncode=-1)
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --wait')
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--wait'])
 
     def test_install_helm_failed(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')


### PR DESCRIPTION
This PR contains a number of smaller changes and improvements to `lbc.py`:
- Make it work on systems that don't have `python2`, refuse to run with an error message on systems where `python` is `python3`.
- Add `uninstall` subcommand which basically does `helm delete --purge` in a safer way
- Add `--set` argument (https://github.com/lightbend/es-backend/issues/391)
- Add `--wait` argument
- Handle `helm status` output better (https://github.com/lightbend/es-backend/issues/433)
- Add `--reuse-resources` flag which should help with installing multiple consoles in different namespaces (https://github.com/lightbend/es-backend/issues/432). Note: this will work in the next release which will include @jsravn changes (https://github.com/lightbend/helm-charts/pull/179, https://github.com/lightbend/helm-charts/pull/180), so it is behind a flag for now.
- Change `enterprise-suite/Makefile` to use `lbc.py` for running minikube tests
- Fix a bug where script would crash when trying to run unavailable command in linux (eg. when running `minishift status` when minishift is not installed)