### PR TITLE
Add exposeServices flag, deprecate minikube flag

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -114,7 +114,7 @@ spec:
   - port: 9093
     protocol: TCP
     targetPort: 9093
-    nodePort: 30093
+    nodePort: {{ .Values.alertManagerExposePort }} 
   selector:
     app: prometheus
     component: alertmanager

--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -103,7 +103,7 @@ spec:
           emptyDir: {}
           {{ end }}
 
-{{ if .Values.minikube }}
+{{ if or .Values.exposeServices .Values.minikube }}
 ---
 apiVersion: v1
 kind: Service
@@ -118,7 +118,7 @@ spec:
   selector:
     app: prometheus
     component: alertmanager
-  type: NodePort
+  type: {{ .Values.exposeServices | default "NodePort" }}
 {{ end }}
 
 ---

--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -44,7 +44,7 @@ spec:
         configMap:
           name: es-console
 
-{{ if .Values.minikube }}
+{{ if or .Values.exposeServices .Values.minikube }}
 ---
 apiVersion: v1
 kind: Service
@@ -58,7 +58,7 @@ spec:
     nodePort: 30080
   selector:
     run: es-console
-  type: NodePort
+  type: {{ .Values.exposeServices | default "NodePort" }}
 {{ end }}
 
 ---

--- a/enterprise-suite/templates/es-console.yaml
+++ b/enterprise-suite/templates/es-console.yaml
@@ -55,7 +55,7 @@ spec:
   - port: 80
     protocol: TCP
     targetPort: 8080
-    nodePort: 30080
+    nodePort: {{ .Values.esConsoleExposePort }}
   selector:
     run: es-console
   type: {{ .Values.exposeServices | default "NodePort" }}

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -63,7 +63,7 @@ spec:
     component: "server"
   type: "ClusterIP"
 
-{{ if .Values.minikube }}
+{{ if or .Values.exposeServices .Values.minikube }}
 ---
 apiVersion: v1
 kind: Service
@@ -78,7 +78,7 @@ spec:
   selector:
     app: grafana
     component: server
-  type: NodePort
+  type: {{ .Values.exposeServices | default "NodePort" }}
 {{ end }}
 
 ---

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -74,7 +74,7 @@ spec:
   - port: 3000
     protocol: TCP
     targetPort: 3000
-    nodePort: 30030
+    nodePort: {{ .Values.esGrafanaExposePort }}
   selector:
     app: grafana
     component: server

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -261,7 +261,7 @@ spec:
     app: prometheus
     component: server
 
-{{ if .Values.minikube }}
+{{ if or .Values.exposeServices .Values.minikube }}
 ---
 apiVersion: v1
 kind: Service
@@ -272,11 +272,11 @@ spec:
   - port: 9090
     protocol: TCP
     targetPort: 9090
-    nodePort: 30090
+    nodePort: {{ .Values.prometheusExposePort }} 
   selector:
     app: prometheus
     component: server
-  type: NodePort
+  type: {{ .Values.exposeServices | default "NodePort" }}
 {{ end }}
 
 ---

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -81,6 +81,15 @@ alertManagerConfigMap: alertmanager-default
 # Service type for exposing Console outside the cluster. Can be "NodePort", "LoadBalancer" or "false".
 exposeServices: false
 
+# If exposeServices is set to "NodePort" or "LoadBalancer", Grafana will be exposed on this port.
+esGrafanaExposePort: 30030
+# If exposeServices is set to "NodePort" or "LoadBalancer", Console will be exposed on this port.
+esConsoleExposePort: 30080
+# If exposeServices is set to "NodePort" or "LoadBalancer", Prometheus will be exposed on this port.
+prometheusExposePort: 30090
+# If exposeServices is set to "NodePort" or "LoadBalancer", Alertmanager will be exposed on this port.
+alertManagerExposePort: 30093
+
 #################################################
 # RBAC
 #

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -65,7 +65,7 @@ daemonSetApiVersion: apps/v1beta2
 imagePullPolicy: IfNotPresent
 # prometheus annotation domain, e.g. `domain/scrape=true`
 prometheusDomain: prometheus.io
-# minikube debug resources
+# (deprecated) minikube debug resources - use exposeServices=NodePort instead
 minikube: false
 # Run pods as the given UID. There is no sensible default for this, so customers need to provide it.
 podUID:
@@ -78,6 +78,8 @@ imageCredentials:
 # Alertmanager ConfigMap. Set to the name of a ConfigMap, with a file `alertmanager.yml`.
 alertManagerConfigMap: alertmanager-default
 
+# Service type for exposing Console outside the cluster. Can be "NodePort", "LoadBalancer" or "false".
+exposeServices: false
 
 #################################################
 # RBAC


### PR DESCRIPTION
For https://github.com/lightbend/es-backend/issues/410

I'm a total noob with Helm charts. Does this look ok?

Tests on minikube seem to work:

```
scripts/lbc.py install --local-chart=. --set exposeServices=NodePort
```
```
scripts/lbc.py install --local-chart=. --set exposeServices=LoadBalancer
```