### PR TITLE
Add test verifying es_monitor_type on automatic metrics

### DIFF
--- a/enterprise-suite/tests/smoke_prometheus
+++ b/enterprise-suite/tests/smoke_prometheus
@@ -240,7 +240,7 @@ prom_has_data "$app_instances"
 # automatic metrics should gain an es_monitor_type label when a custom monitor is created
 curl -XPOST -H "Content-Type: application/json" -H 'Author-Name: Me' -H 'Author-Email: me@lightbend.com' -H 'Message: testing!' \
     "$ES_MONITOR_API/monitors/es-test/mytest" \
-    --data '{"model":"threshold","parameters":{"name":"my_custom_monitor","metric":"up","comparator":"<","threshold":"1","window":"5m","confidence":"0.5","severity":"critical","summary":"pod not up","description":"","monitorType":""}}'
+    --data '{"model":"threshold","parameters":{"name":"my_custom_monitor","metric":"up{es_workload=\"es-test\"}","comparator":"<","threshold":"1","window":"5m","confidence":"0.5","severity":"critical","summary":"pod not up","description":"","monitorType":"es-test"}}'
 
 busy_wait model_exists my_custom_monitor
 

--- a/enterprise-suite/tests/smoke_prometheus
+++ b/enterprise-suite/tests/smoke_prometheus
@@ -44,6 +44,11 @@ prom_has_no_data() {
   T $? timeseries: "$*"
 }
 
+model_exists() {
+  results=$( prom_query "model{name=\"$1\"}" | jq '.data.result | length' )
+  ! [[ results -eq 0 ]]
+}
+
 #
 # log fetchers
 #
@@ -232,6 +237,15 @@ busy_wait app_data
 
 prom_has_data "$app_instances"
 
+# automatic metrics should gain an es_monitor_type label when a custom monitor is created
+curl -XPOST -H "Content-Type: application/json" -H 'Author-Name: Me' -H 'Author-Email: me@lightbend.com' -H 'Message: testing!' \
+    "$ES_MONITOR_API/monitors/es-test/mytest" \
+    --data '{"model":"threshold","parameters":{"name":"my_custom_monitor","metric":"up","comparator":"<","threshold":"1","window":"5m","confidence":"0.5","severity":"critical","summary":"pod not up","description":"","monitorType":""}}'
+
+busy_wait model_exists my_custom_monitor
+
+prom_has_data 'up{es_workload="es-test", es_monitor_type="es-test"}'
+
 # app via 'Pod' service discovery with multiple metric ports
 app_instances_with_multiple_ports='count( count by (instance) (ohai{es_workload="es-test-with-multiple-ports", namespace="lightbend"}) ) == 4'
 app_data_with_multiple_ports() {
@@ -251,12 +265,6 @@ app_data_via_service() {
 busy_wait app_data_via_service
 
 prom_has_data "$app_instances_via_service"
-
-
-model_exists() {
-  results=$( prom_query "model{name=\"$1\"}" | jq '.data.result | length' )
-  ! [[ results -eq 0 ]]
-}
 
 # Succeeds if all data for the workload $1 has a matching es_monitor_type
 # Note we're currently ignoring health metrics because 'bad' data can stick around for 15m given their time window.

--- a/enterprise-suite/tests/smoke_prometheus
+++ b/enterprise-suite/tests/smoke_prometheus
@@ -237,10 +237,10 @@ busy_wait app_data
 
 prom_has_data "$app_instances"
 
-# automatic metrics should gain an es_monitor_type label when a custom monitor is created
+# Pod discovery - automatic metrics should gain an es_monitor_type label when a custom monitor is created
 curl -XPOST -H "Content-Type: application/json" -H 'Author-Name: Me' -H 'Author-Email: me@lightbend.com' -H 'Message: testing!' \
     "$ES_MONITOR_API/monitors/es-test/mytest" \
-    --data '{"model":"threshold","parameters":{"name":"my_custom_monitor","metric":"up{es_workload=\"es-test\"}","comparator":"<","threshold":"1","window":"5m","confidence":"0.5","severity":"critical","summary":"pod not up","description":"","monitorType":"es-test"}}'
+    --data '{"model":"threshold","parameters":{"name":"my_custom_monitor","metric":"up","comparator":"<","threshold":"1","window":"5m","confidence":"0.5","severity":"critical","summary":"pod not up","description":"","monitorType":"es-test"}}'
 
 busy_wait model_exists my_custom_monitor
 
@@ -265,6 +265,15 @@ app_data_via_service() {
 busy_wait app_data_via_service
 
 prom_has_data "$app_instances_via_service"
+
+# 'Service' discovery - automatic metrics should gain an es_monitor_type label when a custom monitor is created
+curl -XPOST -H "Content-Type: application/json" -H 'Author-Name: Me' -H 'Author-Email: me@lightbend.com' -H 'Message: testing!' \
+    "$ES_MONITOR_API/monitors/es-test-via-service/mytest" \
+    --data '{"model":"threshold","parameters":{"name":"my_custom_monitor_for_service","metric":"up","comparator":"<","threshold":"1","window":"5m","confidence":"0.5","severity":"critical","summary":"pod not up","description":"","monitorType":"es-test-via-service"}}'
+
+busy_wait model_exists my_custom_monitor_for_service
+
+prom_has_data 'up{es_workload="es-test-via-service", es_monitor_type="es-test-via-service"}'
 
 # Succeeds if all data for the workload $1 has a matching es_monitor_type
 # Note we're currently ignoring health metrics because 'bad' data can stick around for 15m given their time window.


### PR DESCRIPTION
Like `up` and `scrape_duration_time`.

Verifies https://github.com/lightbend/helm-charts/pull/178