### PR TITLE
Make `./lbc.py install` try to reuse resources from previous failed install, also better python3 behaviour

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -4,18 +4,20 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import sys 
+import subprocess
 
 # Note: this script expects to run on python2. Some systems map 'python'
 # executable name to python3, detect that and complain.
 if sys.version_info >= (3, 0):
-    sys.exit(("It appears 'python' in your PATH is Python 3.X, please "
-              "run this script using Python 2: 'python2 lbc.py'"))
+    print(("It appears 'python' in your PATH is Python 3.X, please "
+           "run this script using Python 2: 'python2 lbc.py'\n"))
+    proc = subprocess.run(['python2'] + sys.argv)
+    sys.exit(proc.returncode)
 
 import os
 import glob
 import shlex
 import shutil
-import subprocess
 import threading
 import tempfile
 import re

--- a/enterprise-suite/scripts/lbc_test.py
+++ b/enterprise-suite/scripts/lbc_test.py
@@ -106,12 +106,30 @@ class LbcTest(unittest.TestCase):
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--wait'])
 
     def test_install_helm_failed(self):
+        # Failed previous install, no PVCs or clusterroles found for reuse
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
         expect_cmd(r'helm status enterprise-suite', returncode=0,
                    stdout='LAST DEPLOYED: Tue Nov 13 09:59:46 2018\nNAMESPACE: lightbend\nSTATUS: FAILED\nNOTES: blah')
         expect_cmd(r'helm delete --purge enterprise-suite')
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
+        expect_cmd(r'kubectl get clusterroles --no-headers')
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
+        lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
+
+    def test_install_helm_failed_reuse(self):
+        # Failed previous install, PVCs found for reuse
+        expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
+        expect_cmd(r'helm repo update')
+        expect_cmd(r'helm status enterprise-suite', returncode=0,
+                   stdout='LAST DEPLOYED: Tue Nov 13 09:59:46 2018\nNAMESPACE: lightbend\nSTATUS: FAILED\nNOTES: blah')
+        expect_cmd(r'helm delete --purge enterprise-suite')
+        expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers',
+                   stdout=('alertmanager-storage Bound pvc-a3815792-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
+                           'es-grafana-storage Bound pvc-a3824cbc-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
+                           'prometheus-storage Bound pvc-a382f4c1-e744-11e8-a15b-080027dccb43 256Gi RWO standard 1h\n'))
+        expect_cmd(r'kubectl get clusterroles --no-headers')
+        expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set createPersistentVolumes=false')
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file])
 
     def test_install_not_finished(self):
@@ -182,12 +200,12 @@ class LbcTest(unittest.TestCase):
     def test_install_reuse_pvcs(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
+        expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers',
                    stdout=('alertmanager-storage Bound pvc-a3815792-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
                            'es-grafana-storage Bound pvc-a3824cbc-e744-11e8-a15b-080027dccb43 32Gi RWO standard 1h\n'
                            'prometheus-storage Bound pvc-a382f4c1-e744-11e8-a15b-080027dccb43 256Gi RWO standard 1h\n'))
         expect_cmd(r'kubectl get clusterroles --no-headers')
-        expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set createPersistentVolumes=false')
 
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--reuse-resources'])
@@ -195,10 +213,10 @@ class LbcTest(unittest.TestCase):
     def test_install_reuse_cluster_roles(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
+        expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'kubectl get clusterroles --no-headers',
                    stdout='prometheus-kube-state-metrics 72m\nprometheus-server 72m')
-        expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+  --set createClusterRoles=false')
 
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--reuse-resources'])
@@ -206,9 +224,9 @@ class LbcTest(unittest.TestCase):
     def test_install_reuse_resources_negative(self):
         expect_cmd(r'helm repo add es-repo https://repo.lightbend.com/helm-charts')
         expect_cmd(r'helm repo update')
+        expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'kubectl get pvc --namespace=lightbend --no-headers')
         expect_cmd(r'kubectl get clusterroles --no-headers')
-        expect_cmd(r'helm status enterprise-suite', returncode=-1)
         expect_cmd(r'helm install es-repo/enterprise-suite --name enterprise-suite --namespace lightbend --devel --values \S+')
 
         lbc.main(['install', '--skip-checks', '--creds='+self.creds_file, '--reuse-resources'])


### PR DESCRIPTION
For https://github.com/lightbend/es-backend/issues/433

In some cases, I get failed helm install where some resources still get created. After that, `./lbc.py install` tries to clean that up with `helm delete --purge`, but our policy for PVCs prevents them from being deleted. This PR makes `lbc.py` check for existing PVCs if previous install failed, just like when `--reuse-resources` flag is provided.

Also, this PR slightly improves running on python3 - instead of just complaining and quitting, now we try to spawn python2 process. Tested only on Mac OS so far.