### PR TITLE
Minor `lbc.py` credentials check error reporting improvement

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-from __future__ import unicode_literals
 
 import sys 
 import subprocess

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -188,6 +188,15 @@ def check_credentials(creds):
             # Lazy way of verifying returned json - there should be a tag named "latest"
             if '"latest"' in resp.read():
                 success = True
+    except url.HTTPError as err:
+        if err.code == 401:
+            # Unauthorized, error message gets printed by check_credentials caller
+            pass
+        elif err.code == 54:
+            # Code 54 error can be raised when old TLS is used due to old python
+            printerr('error: check_credentials TLS authorization failed; this can be due to an old python version, please try upgrading')
+        else:
+            printerr('error: check_credentials failed: {}'.format(err))
     finally:
         return success 
 


### PR DESCRIPTION
For: https://github.com/lightbend/es-backend/issues/436

This PR makes `lbc.py` report errors that happen during credentials check. I couldn't tie this to any specific python version, my default python 2.7.10 on OS X 10.13 seems to work ok, while the same version on OS X 10.12 can fail. So it's likely a problem with linked library versions.

Additionally, this makes `argparse` error reporting better by removing automatic unicode literals everywhere.

Before:

```
./lbc.py isntall
usage: lbc.py [-h] {install,uninstall,verify,debug-dump} ...
lbc.py: error: argument subcommand: invalid choice: 'isntall' (choose from u'install', u'uninstall', u'verify', u'debug-dump')
```

After:

```
./lbc.py isntall
usage: lbc.py [-h] {install,uninstall,verify,debug-dump} ...
lbc.py: error: argument subcommand: invalid choice: 'isntall' (choose from 'install', 'uninstall', 'verify', 'debug-dump')
```