### PR TITLE
Prefix ClusterRole with namespace of Console install

### DIFF
--- a/enterprise-suite/templates/kube-state-metrics.yaml
+++ b/enterprise-suite/templates/kube-state-metrics.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRole
 metadata:
-  name: prometheus-kube-state-metrics
+  name: {{.Release.Namespace}}:kube-state-metrics
 rules:
 - apiGroups: [""]
   resources:
@@ -48,7 +48,7 @@ metadata:
 roleRef:
   apiGroup: {{ .Values.apiGroupVersion }}
   kind: ClusterRole
-  name: prometheus-kube-state-metrics
+  name: {{.Release.Namespace}}:prometheus-kube-state-metrics
 subjects:
 - kind: ServiceAccount
   name: prometheus-kube-state-metrics

--- a/enterprise-suite/templates/kube-state-metrics.yaml
+++ b/enterprise-suite/templates/kube-state-metrics.yaml
@@ -44,11 +44,11 @@ rules:
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{.Release.Namespace}}:prometheus-kube-state-metrics
+  name: {{.Release.Namespace}}:kube-state-metrics
 roleRef:
   apiGroup: {{ .Values.apiGroupVersion }}
   kind: ClusterRole
-  name: {{.Release.Namespace}}:prometheus-kube-state-metrics
+  name: {{.Release.Namespace}}:kube-state-metrics
 subjects:
 - kind: ServiceAccount
   name: prometheus-kube-state-metrics

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -10,7 +10,7 @@ metadata:
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRole
 metadata:
-  name: prometheus-server
+  name: {{.Release.Namespace}}:prometheus-server
 rules:
 - apiGroups: [""]
   resources:
@@ -36,7 +36,7 @@ metadata:
 roleRef:
   apiGroup: {{ .Values.apiGroupVersion }}
   kind: ClusterRole
-  name: prometheus-server
+  name: {{.Release.Namespace}}:prometheus-server
 subjects:
 - kind: ServiceAccount
   name: prometheus-server


### PR DESCRIPTION
This allows multiple Console installs without any extra work from users.
Prior to that they would have had to set `CreateClusterRoles=false`.