### PR TITLE
Remove expose-* services for everything but console

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -103,24 +103,6 @@ spec:
           emptyDir: {}
           {{ end }}
 
-{{ if or .Values.exposeServices .Values.minikube }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: expose-alertmanager
-spec:
-  ports:
-  - port: 9093
-    protocol: TCP
-    targetPort: 9093
-    nodePort: {{ .Values.alertManagerExposePort }} 
-  selector:
-    app: prometheus
-    component: alertmanager
-  type: {{ .Values.exposeServices | default "NodePort" }}
-{{ end }}
-
 ---
 apiVersion: v1
 kind: Service

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -63,24 +63,6 @@ spec:
     component: "server"
   type: "ClusterIP"
 
-{{ if or .Values.exposeServices .Values.minikube }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: expose-grafana
-spec:
-  ports:
-  - port: 3000
-    protocol: TCP
-    targetPort: 3000
-    nodePort: {{ .Values.esGrafanaExposePort }}
-  selector:
-    app: grafana
-    component: server
-  type: {{ .Values.exposeServices | default "NodePort" }}
-{{ end }}
-
 ---
 {{ if $shouldCreatePVCs }}
 kind: PersistentVolumeClaim
@@ -97,6 +79,7 @@ spec:
     requests:
       storage: {{ .Values.esGrafanaVolumeSize }}
 {{ end }}
+
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -259,24 +259,6 @@ spec:
     app: prometheus
     component: server
 
-{{ if or .Values.exposeServices .Values.minikube }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: expose-prometheus
-spec:
-  ports:
-  - port: 9090
-    protocol: TCP
-    targetPort: 9090
-    nodePort: {{ .Values.prometheusExposePort }} 
-  selector:
-    app: prometheus
-    component: server
-  type: {{ .Values.exposeServices | default "NodePort" }}
-{{ end }}
-
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/enterprise-suite/tests/e2e/scripts/wait_es_services.sh
+++ b/enterprise-suite/tests/e2e/scripts/wait_es_services.sh
@@ -3,8 +3,6 @@
 # wait es_services are ready. polling es-prom-server/es-console/es-grafana
 SERVICES=$(minikube service list)
 CURL='curl --connect-timeout 1 --max-time 1 --output /dev/null --silent'
-PROMETHEUS_URL=`echo "$SERVICES" | grep expose-prometheus | awk  '{print $6}'`
-GRAFANA_URL=`echo "$SERVICES" | grep expose-grafana | awk  '{print $6}'`
 ES_CONSOLE_URL=`echo "$SERVICES" | grep expose-es-console | awk  '{print $6}'`
 
 
@@ -26,7 +24,5 @@ function polling_service {
   echo "$1 is up"
 }
 
-polling_service $PROMETHEUS_URL
 polling_service $ES_CONSOLE_URL
-polling_service $GRAFANA_URL
 echo "poll services takes $seconds sec"

--- a/enterprise-suite/tests/smoke_prometheus
+++ b/enterprise-suite/tests/smoke_prometheus
@@ -18,8 +18,8 @@ set +e
 # prometheus fetchers
 #
 
-PROM=$( busy_wait nodeport expose-prometheus )
 ES_CONSOLE=$( busy_wait nodeport expose-es-console )
+PROM="$ES_CONSOLE/service/prometheus"
 ES_MONITOR_API="$ES_CONSOLE/service/es-monitor-api"
 
 prom_query() {

--- a/enterprise-suite/tests/smoke_proxy
+++ b/enterprise-suite/tests/smoke_proxy
@@ -23,10 +23,6 @@ trap cleanup 0
 
 # Make sure the services are ready
 CONSOLE_NODE_BASE=$( busy_wait nodeport console-server )
-ESMONITOR_NODE_BASE=$( busy_wait nodeport es-monitor-api )
-PROM_NODE_BASE=$( busy_wait nodeport prometheus-server )
-GRAFANA_NODE_BASE=$( busy_wait nodeport grafana-server )
-ALERTMGR_NODE_BASE=$( busy_wait nodeport alertmanager )
 
 # Get port for service in kubernetes.  $1 is service
 getport() {

--- a/enterprise-suite/tests/smoke_services
+++ b/enterprise-suite/tests/smoke_services
@@ -6,26 +6,22 @@ source smokecommon
 
 #set -x
 
-# Base URLs for access via NodePort setup
+# Base URL for access via NodePort setup
 CONSOLE_NODE_BASE=$( busy_wait nodeport expose-es-console )
-GRAFANA_NODE_BASE=$( busy_wait nodeport expose-grafana )
-PROM_NODE_BASE=$( busy_wait nodeport expose-prometheus )
-ALERTMGR_NODE_BASE=$( busy_wait nodeport expose-alertmanager )
 
 # Base URLs for access to services via console using nginx location directives
 GRAFANA_VIA_CONSOLE=${CONSOLE_NODE_BASE}/service/grafana
 PROMETHEUS_VIA_CONSOLE=${CONSOLE_NODE_BASE}/service/prometheus
 ESMONITOR_VIA_CONSOLE=${CONSOLE_NODE_BASE}/service/es-monitor-api
+ALERTMANAGER_VIA_CONSOLE=${CONSOLE_NODE_BASE}/service/alertmanager
 
 # Now run our tests
 test_es_console_responding $CONSOLE_NODE_BASE
-test_grafana_responding $GRAFANA_NODE_BASE
-test_prom_responding $PROM_NODE_BASE
-test_alertmanager_responding $ALERTMGR_NODE_BASE
 
 test_grafana_responding $GRAFANA_VIA_CONSOLE
 test_prom_responding $PROMETHEUS_VIA_CONSOLE
 test_es_monitor_API_responding $ESMONITOR_VIA_CONSOLE
+test_alertmanager_responding $ALERTMANAGER_VIA_CONSOLE
 
 # ...and dump the summary
 test_summary

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -81,14 +81,8 @@ alertManagerConfigMap: alertmanager-default
 # Service type for exposing Console outside the cluster. Can be "NodePort", "LoadBalancer" or "false".
 exposeServices: false
 
-# If exposeServices is set to "NodePort" or "LoadBalancer", Grafana will be exposed on this port.
-esGrafanaExposePort: 30030
 # If exposeServices is set to "NodePort" or "LoadBalancer", Console will be exposed on this port.
 esConsoleExposePort: 30080
-# If exposeServices is set to "NodePort" or "LoadBalancer", Prometheus will be exposed on this port.
-prometheusExposePort: 30090
-# If exposeServices is set to "NodePort" or "LoadBalancer", Alertmanager will be exposed on this port.
-alertManagerExposePort: 30093
 
 #################################################
 # ResourceRequests


### PR DESCRIPTION
For https://github.com/lightbend/es-backend/issues/410

I understand these should be accessed through console now, so this PR removes `expose-prometheus`, `expose-grafana`, `expose-alertmanager` services.