### PR TITLE
Remove createClusterRoles parameter

### DIFF
--- a/enterprise-suite/templates/kube-state-metrics.yaml
+++ b/enterprise-suite/templates/kube-state-metrics.yaml
@@ -1,5 +1,4 @@
 ---
-{{ if .Values.createClusterRoles }}
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRole
 metadata:
@@ -39,7 +38,6 @@ rules:
   resources:
   - horizontalpodautoscalers
   verbs: ["list", "watch"]
-{{ end }}
 ---
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRoleBinding

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -6,7 +6,6 @@ metadata:
   name: prometheus-server
 
 ---
-{{ if .Values.createClusterRoles }}
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRole
 metadata:
@@ -27,7 +26,6 @@ rules:
   verbs: ["get", "list", "watch"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
-{{ end }}
 ---
 apiVersion: {{ .Values.rbacApiVersion }}
 kind: ClusterRoleBinding

--- a/enterprise-suite/values.yaml
+++ b/enterprise-suite/values.yaml
@@ -91,12 +91,6 @@ prometheusExposePort: 30090
 alertManagerExposePort: 30093
 
 #################################################
-# RBAC
-#
-# Create ClusterRoles for RBAC, used by Prometheus for service discovery and kube-state-metrics. Set to false if creating additional Lightbend Consoles in the same cluster, as this is a shared resource.
-createClusterRoles: true
-
-#################################################
 # ResourceRequests
 #
 # default container resource requests for CPU (0.1)


### PR DESCRIPTION
Now that the ClusterRole is prefixed with namespace, we don't need a way
to disable their creation to allow multiple console installs.

Related to https://github.com/lightbend/es-backend/issues/432
and https://github.com/lightbend/helm-charts/pull/196