### PR TITLE
Follow up to `lbc.py` credentials check error reporting change

### DIFF
--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -188,10 +188,10 @@ def check_credentials(creds):
             if '"latest"' in resp.read():
                 success = True
     except url.HTTPError as err:
-        if err.code == 401:
-            # Unauthorized, error message gets printed by check_credentials caller
-            pass
-        elif err.code == 54:
+        if err.code != 401:
+            printerr('error: check_credentials failed: {}'.format(err))
+    except url.URLError as err:
+        if err.reason.errno == 54:
             # Code 54 error can be raised when old TLS is used due to old python
             printerr('error: check_credentials TLS authorization failed; this can be due to an old python version, please try upgrading')
         else:
@@ -415,7 +415,7 @@ def import_credentials():
     return creds
 
 def check_install():
-    def deployment_running(name, optional=False):
+    def deployment_running(name):
         printinfo('Checking deployment {} ... '.format(name), end='')
         stdout, returncode = run('kubectl --namespace {} get deploy/{} --no-headers'
                                  .format(args.namespace, name))

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -415,7 +415,7 @@ def import_credentials():
     return creds
 
 def check_install():
-    def deployment_running(name):
+    def deployment_running(name, optional=False):
         printinfo('Checking deployment {} ... '.format(name), end='')
         stdout, returncode = run('kubectl --namespace {} get deploy/{} --no-headers'
                                  .format(args.namespace, name))

--- a/enterprise-suite/scripts/lbc.py
+++ b/enterprise-suite/scripts/lbc.py
@@ -193,7 +193,7 @@ def check_credentials(creds):
     except url.URLError as err:
         if err.reason.errno == 54:
             # Code 54 error can be raised when old TLS is used due to old python
-            printerr('error: check_credentials TLS authorization failed; this can be due to an old python version, please try upgrading')
+             printerr('error: check_credentials TLS authorization failed; this can be due to an old python version installed on OS X - please upgrade your python version')
         else:
             printerr('error: check_credentials failed: {}'.format(err))
     finally:


### PR DESCRIPTION
For https://github.com/lightbend/es-backend/issues/436

I couldn't test my previous (https://github.com/lightbend/helm-charts/pull/197) error reporting on the actual system where the check fails, so it didn't work. This PR is just a diff that @marcoderama wrote to fix it, thanks!