### PR TITLE
Use Recreate deployment strategy for pods with PVs

### DIFF
--- a/enterprise-suite/templates/alertmanager.yaml
+++ b/enterprise-suite/templates/alertmanager.yaml
@@ -26,6 +26,11 @@ metadata:
   name: prometheus-alertmanager
 spec:
   replicas: 1
+
+  strategy:
+    # Always Recreate to ensure the PVs get released. It's not possible to have two replicas sharing a PV during deployment.
+    type: Recreate
+
   selector:
     matchLabels:
       app: prometheus

--- a/enterprise-suite/templates/es-grafana.yaml
+++ b/enterprise-suite/templates/es-grafana.yaml
@@ -90,6 +90,11 @@ metadata:
     component: server
 spec:
   replicas: 1
+
+  strategy:
+    # Always Recreate to ensure the PVs get released. It's not possible to have two replicas sharing a PV during deployment.
+    type: Recreate
+
   template:
     metadata:
       labels:

--- a/enterprise-suite/templates/prometheus.yaml
+++ b/enterprise-suite/templates/prometheus.yaml
@@ -67,6 +67,11 @@ metadata:
   name: prometheus-server
 spec:
   replicas: 1
+
+  strategy:
+    # Always Recreate to ensure the PVs get released. It's not possible to have two replicas sharing a PV during deployment.
+    type: Recreate
+
   selector:
     matchLabels:
       app: prometheus


### PR DESCRIPTION
Otherwise the PVC may not get released on the old pod, thus preventing
the deployment from proceeding.

Fix https://github.com/lightbend/es-backend/issues/487