### PR TITLE
Fix alertmanager examples

### DIFF
--- a/enterprise-suite/alertmanager/alertmanager.yml
+++ b/enterprise-suite/alertmanager/alertmanager.yml
@@ -13,7 +13,7 @@ route:
   # Wait before sending a new alert for a group.
   group_interval: 5m
   # Group alerts by namespace and workload.
-  group_by: [namespace, es_workload]
+  group_by: [namespace, es_workload, severity]
   routes:
   # team1 Slack
   - match:
@@ -39,7 +39,7 @@ inhibit_rules:
     severity: critical
   target_match:
     severity: warning
-  equal: [alertname]
+  equal: [alertname, namespace, es_workload]
 
 templates:
 # Slack notification templates.

--- a/enterprise-suite/alertmanager/slack.tmpl
+++ b/enterprise-suite/alertmanager/slack.tmpl
@@ -1,3 +1,3 @@
-{{ define "title.slack" }}{{ .GroupLabels.namespace}}/{{ .GroupLabels.es_workload }} [{{ .Status | toUpper }}][{{ .CommonLabels.severity | toUpper }}]{{ end }}
+{{ define "title.slack" }}{{ .GroupLabels.namespace}}/{{ .GroupLabels.es_workload }} [{{ .Status | toUpper }}][{{ .GroupLabels.severity | toUpper }}]{{ end }}
 {{ define "text.slack" }}{{ range .Alerts }}_{{ .Labels.name }}_
 {{ end }}{{- end -}}


### PR DESCRIPTION
- Group on severity as well, so we don't mix and duplicate
warning/critical alerts in the same groups.
- Inhibit correctly on namespace and workload, so we don't inhibit
alerts in other workloads!