### PR TITLE
Tweak smoke_ingress-tls in the same was as smoke_ingress (102e601) to red…

### DIFF
--- a/enterprise-suite/tests/smoke_ingress-tls
+++ b/enterprise-suite/tests/smoke_ingress-tls
@@ -36,11 +36,11 @@ trap cleanup 0
 #   Normal  UPDATE  3s    nginx-ingress-controller  Ingress lightbend/ingress-test-tls
 #
 ingress_ready() {
-    # debug output
-    #kubectl describe ing/ingress-test-tls -n lightbend
     # ingress can take up to 1m to get ready
-    sleep 2
     kubectl describe ing/ingress-test-tls -n lightbend | awk 'END { exit !( $1 == "Normal"  &&  $2 == "UPDATE" ) }'
+    status=$?
+    sleep 2
+    return $status
 }
 
 # Makes sure expose-es-console is ready


### PR DESCRIPTION
…uce/eliminate transient failures.

Nothing fancy here.  This stunt seems to have worked to reduce the flakiness of the `smoke_ingress` test.